### PR TITLE
use preDestroy to stop database

### DIFF
--- a/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageManagerFactory.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageManagerFactory.java
@@ -16,6 +16,7 @@
 package io.micronaut.microstream.conf;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
@@ -52,6 +53,7 @@ public class EmbeddedStorageManagerFactory {
      * @return EmbeddedStorageManager
      */
     @EachBean(EmbeddedStorageFoundation.class)
+    @Bean(preDestroy = "shutdown")
     @Singleton
     public EmbeddedStorageManager createEmbeddedStorageManager(EmbeddedStorageFoundation<?> foundation,
                                                                @Parameter String name) {


### PR DESCRIPTION
See: https://docs.microstream.one/manual/storage/getting-started.html#_stopping_a_live_database

https://docs.micronaut.io/latest/guide/#factories

> To allow the resulting bean to participate in the application context shutdown process, annotate the method with @Bean and set the preDestroy argument to the name of the method to be called to close the bean.