### PR TITLE
feat: @Store annotation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ reactor-test = '3.4.15'
 
 managed-microstream-storage-embedded-configuration= { module = 'one.microstream:microstream-storage-embedded-configuration', version.ref = 'managed-microstream' }
 
+micronaut-aop = { module = "io.micronaut:micronaut-aop" }
 micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
 micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
 micronaut-management = { module = "io.micronaut:micronaut-management" }

--- a/microstream-annotations/build.gradle.kts
+++ b/microstream-annotations/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("io.micronaut.build.internal.module")
+}
+
+dependencies {
+    implementation(libs.micronaut.aop)
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * A method such as this:
  * <pre>
  * {@literal @Store(parameters = "customers")}
- * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
+ * protected Customer addCustomer(Map&lt;String, Customer&gt; customers, CustomerSave customerSave) {
  *     String id = UUID.randomUUID().toString();
  *     Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
  *     customers.put(id, customer);
@@ -49,8 +49,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * Becomes
  * <pre>
- * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
- *     return XThreads.executeSynchronized(() -> {
+ * protected Customer addCustomer(Map&lt;String, Customer&gt; customers, CustomerSave customerSave) {
+ *     return XThreads.executeSynchronized(() -&gt; {
  *         String id = UUID.randomUUID().toString();
  *         Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
  *         customers.put(id, customer);
@@ -78,10 +78,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * <p>
  *
+ * <p>
  * Becomes
  * <pre>
  * protected Customer updateCustomer(String id, CustomerSave customerSave) {
- *     XThreads.executeSynchronized(() -> {
+ *     XThreads.executeSynchronized(() -&gt; {
  *         Customer c = data().getCustomers().get(id);
  *         if (c != null) {
  *             c.setFirstName(customerSave.getFirstName());

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
@@ -65,6 +65,21 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * A method such as this:
  * <pre>
+ * {@literal @Store(result = true)}
+ * protected Customer updateCustomer(String id, CustomerSave customerSave) {
+ *     Customer c = data().getCustomers().get(id);
+ *     if (c != null) {
+ *         c.setFirstName(customerSave.getFirstName());
+ *         c.setLastName(customerSave.getLastName());
+ *         return c;
+ *     }
+ *     return null;
+ * }
+ * </pre>
+ * <p>
+ *
+ * Becomes
+ * <pre>
  * protected Customer updateCustomer(String id, CustomerSave customerSave) {
  *     XThreads.executeSynchronized(() -> {
  *         Customer c = data().getCustomers().get(id);
@@ -76,21 +91,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *         }
  *         return null;
  *     }
- * }
- * </pre>
- * <p>
- *
- * Becomes
- * <pre>
- * {@literal @Store(result = true)}
- * protected Customer updateCustomer(String id, CustomerSave customerSave) {
- *     Customer c = data().getCustomers().get(id);
- *     if (c != null) {
- *         c.setFirstName(customerSave.getFirstName());
- *         c.setLastName(customerSave.getLastName());
- *         return c;
- *     }
- *     return null;
  * }
  * </pre>
  * </p>

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.microstream.annotation;
+package io.micronaut.microstream.annotations;
 
 import io.micronaut.aop.Around;
 import io.micronaut.context.annotation.AliasFor;
@@ -26,8 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  *
- * An around annotation for methods which simplifies storing objects
- * in an associated {@link one.microstream.storage.embedded.types.EmbeddedStorageManager}.
+ * An around annotation for methods which simplifies storing objects in an associated Storage Manager.
  *
  * <p>
  * This annotation will wrap the decorated method to ensure thread isolation.
@@ -107,17 +106,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Around
 public @interface Store {
     /**
-     * The optional name qualifier of the {@link one.microstream.storage.types.StorageManager} to use.
+     * The optional name qualifier of the StorageManager to use.
      * If your application only have a Microstream instance, this is not required
      *
-     * @return The name qualifier of the {@link one.microstream.storage.types.StorageManager} to use.
+     * @return The name qualifier of the StorageManager to use.
      */
     @AliasFor(member = "value")
     String name() default "";
 
     /**
-     * parameters which should be stored in the associated {@link one.microstream.storage.types.StorageManager}.
-     * @return parameters name which should be stored in the associated {@link one.microstream.storage.types.StorageManager}.
+     * parameters which should be stored in the associated StorageManager.
+     * @return parameters name which should be stored in the associated StorageManager.
      */
     String[] parameters() default {};
 

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Utility classes to map to the {@link @Store} annotation.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+public final class StoreAnnotationMapperUtils {
+
+    private static final String STRATEGY = "strategy";
+    private static final String NAME = "name";
+
+    private StoreAnnotationMapperUtils() {
+
+    }
+
+    @NonNull
+    public static AnnotationValueBuilder<Store> annotationValueBuilder(@NonNull AnnotationValue<?> annotation) {
+        StoringStrategy storingStrategy = annotation.get(STRATEGY, StoringStrategy.class).orElse(StoringStrategy.LAZY);
+        Optional<String> name = annotation.get(NAME, String.class);
+        AnnotationValueBuilder<Store> builder = AnnotationValue.builder(Store.class)
+            .member(STRATEGY, storingStrategy);
+        if (name.isPresent()) {
+            builder = builder.member(NAME, name.get());
+        }
+        return builder;
+    }
+
+    @NonNull
+    public static List<AnnotationValue<?>> map(@NonNull AnnotationValue<?> annotation,
+                                               @NonNull Consumer<AnnotationValueBuilder<Store>> builderConsumer) {
+        AnnotationValueBuilder<Store> builder = StoreAnnotationMapperUtils.annotationValueBuilder(annotation);
+        builderConsumer.accept(builder);
+        List<AnnotationValue<?>> annotationValues = new ArrayList<>(1);
+        annotationValues.add(builder.build());
+        return annotationValues;
+    }
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * Utility classes to map to the {@link @Store} annotation.
+ * Utility classes to map to the {@link Store} annotation.
  * @author Sergio del Amo
  * @since 1.0.0
  */

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreAnnotationMapperUtils.java
@@ -40,7 +40,7 @@ public final class StoreAnnotationMapperUtils {
 
     @NonNull
     public static AnnotationValueBuilder<Store> annotationValueBuilder(@NonNull AnnotationValue<?> annotation) {
-        StoringStrategy storingStrategy = annotation.get(STRATEGY, StoringStrategy.class).orElse(StoringStrategy.LAZY);
+        StoringStrategy storingStrategy = annotation.enumValue(STRATEGY, StoringStrategy.class).orElse(StoringStrategy.LAZY);
         Optional<String> name = annotation.get(NAME, String.class);
         AnnotationValueBuilder<Store> builder = AnnotationValue.builder(Store.class)
             .member(STRATEGY, storingStrategy);

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.context.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * An around annotation for methods which simplifies storing objects in an associated Store Manager.
+ *
+ * <p>
+ * This annotation will wrap the decorated method to ensure thread isolation.
+ * </p>
+ * <p>
+ * You can store method parameters.
+ * </p>
+ * <p>
+ * A method such as this:
+ * <pre>
+ * {@literal @Store(parameters = "customers")}
+ * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
+ *     String id = UUID.randomUUID().toString();
+ *     Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
+ *     customers.put(id, customer);
+ *     return customer;
+ * }
+ * </pre>
+ * <p>
+ *
+ * Becomes
+ * <pre>
+ * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
+ *     return XThreads.executeSynchronized(() -> {
+ *         String id = UUID.randomUUID().toString();
+ *         Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
+ *         customers.put(id, customer);
+ *         embeddedStorageManager.store(customers);
+ *         return customer;
+ *     });
+ * }
+ * </pre>
+ *
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @since 1.0.0
+ * @author Tim Yates
+ * @author Sergio del Amo
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface StoreParams {
+    /**
+     * The optional name qualifier of the Store Manager to use.
+     * If your application only have a Microstream instance, this is not required
+     *
+     * @return The name qualifier of the Store Manager to use.
+     */
+    @AliasFor(member = "value")
+    String name() default "";
+
+    /**
+     * parameters which should be stored in the associated Store Manager.
+     * @return parameters name which should be stored in the associated Store Manager.
+     */
+    String[] value();
+
+    /**
+     * The Storing strategy. Defaults to Lazy.
+     * @return Storing Strategy;
+     */
+    StoringStrategy strategy() default StoringStrategy.LAZY;
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * A method such as this:
  * <pre>
  * {@literal @Store(parameters = "customers")}
- * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
+ * protected Customer addCustomer(Map&lt;String, Customer&gt; customers, CustomerSave customerSave) {
  *     String id = UUID.randomUUID().toString();
  *     Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
  *     customers.put(id, customer);
@@ -49,8 +49,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * Becomes
  * <pre>
- * protected Customer addCustomer(Map<String, Customer> customers, CustomerSave customerSave) {
- *     return XThreads.executeSynchronized(() -> {
+ * protected Customer addCustomer(Map&lt;String, Customer&gt; customers, CustomerSave customerSave) {
+ *     return XThreads.executeSynchronized(() -&gt; {
  *         String id = UUID.randomUUID().toString();
  *         Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
  *         customers.put(id, customer);

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParamsAnnotationMapper.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParamsAnnotationMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+
+/**
+ * Maps the {@link StoreParams} annotation to the {@link Store} annotation.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+@Internal
+public class StoreParamsAnnotationMapper implements TypedAnnotationMapper<StoreParams> {
+
+    public static final String PARAMETERS = "parameters";
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<StoreParams> annotation, VisitorContext visitorContext) {
+        return StoreAnnotationMapperUtils.map(annotation, builder -> builder.member(PARAMETERS, annotation.stringValues()));
+    }
+
+    @Override
+    public Class<StoreParams> annotationType() {
+        return StoreParams.class;
+    }
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
@@ -38,6 +38,21 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * A method such as this:
  * <pre>
+ * {@literal @StoreReturn}
+ * protected Customer updateCustomer(String id, CustomerSave customerSave) {
+ *     Customer c = data().getCustomers().get(id);
+ *     if (c != null) {
+ *         c.setFirstName(customerSave.getFirstName());
+ *         c.setLastName(customerSave.getLastName());
+ *         return c;
+ *     }
+ *     return null;
+ * }
+ * </pre>
+ * <p>
+ *
+ * Becomes
+ * <pre>
  * protected Customer updateCustomer(String id, CustomerSave customerSave) {
  *     XThreads.executeSynchronized(() -> {
  *         Customer c = data().getCustomers().get(id);
@@ -49,21 +64,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *         }
  *         return null;
  *     }
- * }
- * </pre>
- * <p>
- *
- * Becomes
- * <pre>
- * {@literal @StoreReturn}
- * protected Customer updateCustomer(String id, CustomerSave customerSave) {
- *     Customer c = data().getCustomers().get(id);
- *     if (c != null) {
- *         c.setFirstName(customerSave.getFirstName());
- *         c.setLastName(customerSave.getLastName());
- *         return c;
- *     }
- *     return null;
  * }
  * </pre>
  * </p>

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.context.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * An around annotation for methods which simplifies storing objects in an associated Store Manager.
+ *
+ * <p>
+ * This annotation will wrap the decorated method to ensure thread isolation.
+ * </p>
+ * <p>
+ * You can store a Method return statement.
+ * </p>
+ *
+ * <p>
+ * A method such as this:
+ * <pre>
+ * protected Customer updateCustomer(String id, CustomerSave customerSave) {
+ *     XThreads.executeSynchronized(() -> {
+ *         Customer c = data().getCustomers().get(id);
+ *         if (c != null) {
+ *             c.setFirstName(customerSave.getFirstName());
+ *             c.setLastName(customerSave.getLastName());
+ *             embeddedStorageManager.store(c);
+ *             return c;
+ *         }
+ *         return null;
+ *     }
+ * }
+ * </pre>
+ * <p>
+ *
+ * Becomes
+ * <pre>
+ * {@literal @StoreReturn}
+ * protected Customer updateCustomer(String id, CustomerSave customerSave) {
+ *     Customer c = data().getCustomers().get(id);
+ *     if (c != null) {
+ *         c.setFirstName(customerSave.getFirstName());
+ *         c.setLastName(customerSave.getLastName());
+ *         return c;
+ *     }
+ *     return null;
+ * }
+ * </pre>
+ * </p>
+ *
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @since 1.0.0
+ * @author Sergio del Amo
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface StoreReturn {
+    /**
+     * The optional name qualifier of the Storage Manager to use.
+     * If your application only have a Microstream instance, this is not required
+     *
+     * @return The name qualifier of the Storage Manager to use.
+     */
+    @AliasFor(member = "value")
+    String name() default "";
+
+    /**
+     * The Storing strategy. Defaults to Lazy.
+     * @return Storing Strategy;
+     */
+    StoringStrategy strategy() default StoringStrategy.LAZY;
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturnAnnotationMapper.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturnAnnotationMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import java.util.List;
+
+
+/**
+ * Maps the {@link StoreReturn} annotation to the {@link Store} annotation.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+@Internal
+public class StoreReturnAnnotationMapper implements TypedAnnotationMapper<StoreReturn> {
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<StoreReturn> annotation, VisitorContext visitorContext) {
+        return StoreAnnotationMapperUtils.map(annotation, builder -> builder.member("result", true));
+    }
+
+    @Override
+    public Class<StoreReturn> annotationType() {
+        return StoreReturn.class;
+    }
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRoot.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRoot.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.context.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * An around annotation for methods which saves the Root Object of a Microstream instance.
+ *
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @since 1.0.0
+ * @author Sergio del Amo
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface StoreRoot {
+    /**
+     * The optional name qualifier of the StorageManager to use.
+     * If your application only have a Microstream instance, this is not required
+     *
+     * @return The name qualifier of the StorageManager to use.
+     */
+    @AliasFor(member = "value")
+    String name() default "";
+
+    /**
+     * The Storing strategy. Defaults to Lazy.
+     * @return Storing Strategy;
+     */
+    StoringStrategy strategy() default StoringStrategy.LAZY;
+
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRootAnnotationMapper.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRootAnnotationMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotations;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import java.util.List;
+
+
+/**
+ * Maps the {@link StoreRoot} annotation to the {@link Store} annotation.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+@Internal
+public class StoreRootAnnotationMapper implements TypedAnnotationMapper<StoreRoot> {
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<StoreRoot> annotation, VisitorContext visitorContext) {
+        return StoreAnnotationMapperUtils.map(annotation, builder -> builder.member("root", true));
+    }
+
+    @Override
+    public Class<StoreRoot> annotationType() {
+        return StoreRoot.class;
+    }
+}

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
@@ -33,5 +33,5 @@ public enum StoringStrategy {
      * In eager storing mode referenced instances are stored even if they had been stored before.
      * Contrary to Lazy storing this will also store modified child objects at the cost of performance.
      */
-    EAGER;
+    EAGER
 }

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
@@ -16,7 +16,7 @@
 package io.micronaut.microstream.annotations;
 
 /**
- * Defines the way the instance that will be stored in the {@link one.microstream.storage.types.StorageManager}.
+ * Defines the way the instance that will be stored in the Store Manager.
  * <a href="https://docs.microstream.one/manual/storage/storing-data/lazy-eager-full.html">Lazy and Eager Storing</a>
  * @author Sergio del Amo
  * @since 1.0.0

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoringStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.microstream.annotation;
+package io.micronaut.microstream.annotations;
 
 /**
  * Defines the way the instance that will be stored in the {@link one.microstream.storage.types.StorageManager}.

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/package-info.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/package-info.java
@@ -18,4 +18,4 @@
  * @author Sergio del Amo
  * @since 1.0.0
  */
-package io.micronaut.microstream.annotation;
+package io.micronaut.microstream.annotations;

--- a/microstream-annotations/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/microstream-annotations/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,0 +1,3 @@
+io.micronaut.microstream.annotations.StoreRootAnnotationMapper
+io.micronaut.microstream.annotations.StoreReturnAnnotationMapper
+io.micronaut.microstream.annotations.StoreParamsAnnotationMapper

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreParamsAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreParamsAnnotationMapperSpec.groovy
@@ -31,5 +31,8 @@ class StoreParamsAnnotationMapperSpec extends Specification {
         StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
         ["customers"] == annotationValue.stringValues("parameters")
         !annotationValue.booleanValue("result").orElse(false)
+
+        and:
+        StoreParams.class == mapper.annotationType()
     }
 }

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreParamsAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreParamsAnnotationMapperSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.microstream.annotations
+
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.visitor.VisitorContext
+import spock.lang.Specification
+
+class StoreParamsAnnotationMapperSpec extends Specification {
+
+    void "StoreParams is mapped to Store"() {
+        when:
+        StoreParamsAnnotationMapper mapper = new StoreParamsAnnotationMapper()
+        def annotation = Stub(AnnotationValue<StoreParams>) {
+            enumValue(_, StoringStrategy.class) >> Optional.of(StoringStrategy.EAGER)
+            get(_, String.class) >> Optional.of("main")
+            stringValues() >> ['customers']
+        }
+        def visitorContext = Mock(VisitorContext)
+        List<AnnotationValue<?>> result = mapper.map(annotation, visitorContext)
+
+        then:
+        result
+        result.size() == 1
+
+        when:
+        AnnotationValue<Store> annotationValue = (AnnotationValue<Store>) result[0]
+
+        then:
+        annotationValue.stringValue("name").isPresent()
+        "main" == annotationValue.stringValue("name").get()
+        !annotationValue.booleanValue("root").orElse(false)
+        StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
+        ["customers"] == annotationValue.stringValues("parameters")
+        !annotationValue.booleanValue("result").orElse(false)
+    }
+}

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreReturnAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreReturnAnnotationMapperSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.microstream.annotations
+
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.visitor.VisitorContext
+import spock.lang.Specification
+
+class StoreReturnAnnotationMapperSpec extends Specification {
+
+    void "StoreReturn is mapped to Store"() {
+        when:
+        StoreReturnAnnotationMapper mapper = new StoreReturnAnnotationMapper()
+        def annotation = Stub(AnnotationValue<StoreReturn>) {
+            enumValue(_, StoringStrategy.class) >> Optional.of(StoringStrategy.EAGER)
+            get(_, String.class) >> Optional.of("main")
+        }
+        def visitorContext = Mock(VisitorContext)
+        List<AnnotationValue<?>> result = mapper.map(annotation, visitorContext)
+
+        then:
+        result
+        result.size() == 1
+
+        when:
+        AnnotationValue<Store> annotationValue = (AnnotationValue<Store>) result[0]
+
+        then:
+        annotationValue.stringValue("name").isPresent()
+        "main" == annotationValue.stringValue("name").get()
+        !annotationValue.booleanValue("root").orElse(false)
+        StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
+        !annotationValue.stringValues("params")
+        annotationValue.booleanValue("result").orElse(false)
+    }
+}

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreReturnAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreReturnAnnotationMapperSpec.groovy
@@ -30,5 +30,8 @@ class StoreReturnAnnotationMapperSpec extends Specification {
         StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
         !annotationValue.stringValues("params")
         annotationValue.booleanValue("result").orElse(false)
+
+        and:
+        StoreReturn.class == mapper.annotationType()
     }
 }

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreRootAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreRootAnnotationMapperSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.microstream.annotations
+
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.visitor.VisitorContext
+import spock.lang.Specification
+
+class StoreRootAnnotationMapperSpec extends Specification {
+
+    void "StoreRoot is mapped to Store"() {
+        when:
+        StoreRootAnnotationMapper mapper = new StoreRootAnnotationMapper()
+        def annotation = Stub(AnnotationValue<StoreRoot>) {
+            enumValue(_, StoringStrategy.class) >> Optional.of(StoringStrategy.EAGER)
+            get(_, String.class) >> Optional.of("main")
+        }
+        def visitorContext = Mock(VisitorContext)
+        List<AnnotationValue<?>> result = mapper.map(annotation, visitorContext)
+
+        then:
+        result
+        result.size() == 1
+
+        when:
+        AnnotationValue<Store> annotationValue = (AnnotationValue<Store>) result[0]
+
+        then:
+        annotationValue.stringValue("name").isPresent()
+        "main" == annotationValue.stringValue("name").get()
+        annotationValue.booleanValue("root").orElse(false)
+        StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
+        !annotationValue.stringValues("params")
+        !annotationValue.booleanValue("result").orElse(false)
+    }
+}

--- a/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreRootAnnotationMapperSpec.groovy
+++ b/microstream-annotations/src/test/groovy/io/micronaut/microstream/annotations/StoreRootAnnotationMapperSpec.groovy
@@ -30,5 +30,9 @@ class StoreRootAnnotationMapperSpec extends Specification {
         StoringStrategy.EAGER == annotationValue.enumValue("strategy", StoringStrategy.class).orElse(StoringStrategy.LAZY)
         !annotationValue.stringValues("params")
         !annotationValue.booleanValue("result").orElse(false)
+
+        and:
+        StoreRoot.class == mapper.annotationType()
+
     }
 }

--- a/microstream/build.gradle.kts
+++ b/microstream/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation(libs.micronaut.management)
     testImplementation(libs.micronaut.http.server.netty)
     testImplementation(libs.micronaut.http.client)
+    testImplementation(project(":microstream-annotations"))
 }
 
 micronautBuild {

--- a/microstream/build.gradle.kts
+++ b/microstream/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(libs.micronaut.micrometer.core)
+    compileOnly(project(":microstream-annotations"))
     api(libs.managed.microstream.storage.embedded.configuration)
 
     compileOnly(libs.micronaut.management)

--- a/microstream/src/main/java/io/micronaut/microstream/DefaultRootProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/DefaultRootProvider.java
@@ -18,22 +18,6 @@ package io.micronaut.microstream;
 import io.micronaut.context.annotation.EachBean;
 import one.microstream.storage.types.StorageManager;
 
-/*
- * Copyright 2017-2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Creates a bean of type {@link RootProvider} for each {@link StorageManager}.
  * @param <T> The Root Instance Type

--- a/microstream/src/main/java/io/micronaut/microstream/DefaultRootProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/DefaultRootProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream;
+
+import io.micronaut.context.annotation.EachBean;
+import one.microstream.storage.types.StorageManager;
+
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Creates a bean of type {@link RootProvider} for each {@link StorageManager}.
+ * @param <T> The Root Instance Type
+ */
+@EachBean(StorageManager.class)
+public class DefaultRootProvider<T> implements RootProvider<T> {
+    private final StorageManager storageManager;
+
+    /**
+     *
+     * @param storageManager StorageManager
+     */
+    public DefaultRootProvider(StorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @Override
+    public T root() {
+        return (T) storageManager.root();
+    }
+}

--- a/microstream/src/main/java/io/micronaut/microstream/RootProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/RootProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream;
+
+/**
+ * Functional interface to ease getting the Root Instance of Microstream Store Manager.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ * @param <T> The type of the root instance.
+ */
+@FunctionalInterface
+public interface RootProvider<T> {
+
+    /**
+     *
+     * @return Root Instance.
+     */
+    T root();
+}

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/StorageInterceptorException.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/StorageInterceptorException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotation;
+
+/**
+ * Exception thrown when an error occurs during storage interceptor processing.
+ *
+ * @author Tim Yates
+ * @since 1.0.0
+ */
+public class StorageInterceptorException extends RuntimeException {
+
+    /**
+     * This is thrown if when there issue finding a storage manager to use.
+     *
+     * @param message The message
+     */
+    public StorageInterceptorException(String message) {
+        super(message);
+    }
+
+    /**
+     * This is thrown if there is an issue calling storeAll after the intercepted method has been executed.
+     *
+     * @param message The message
+     * @param cause The underlying cause of the exception.
+     */
+    public StorageInterceptorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
@@ -107,17 +107,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Around
 public @interface Store {
     /**
-     * The optional name qualifier of the {@link one.microstream.storage.embedded.types.EmbeddedStorageManager} to use.
+     * The optional name qualifier of the {@link one.microstream.storage.types.StorageManager} to use.
      * If your application only have a Microstream instance, this is not required
      *
-     * @return The name qualifier of the {@link one.microstream.storage.embedded.types.EmbeddedStorageManager} to use.
+     * @return The name qualifier of the {@link one.microstream.storage.types.StorageManager} to use.
      */
     @AliasFor(member = "value")
     String name() default "";
 
     /**
-     * parameters which should be stored in the associated {@link one.microstream.storage.embedded.types.EmbeddedStorageManager}.
-     * @return parameters name which should be stored in the associated {@link one.microstream.storage.embedded.types.EmbeddedStorageManager}.
+     * parameters which should be stored in the associated {@link one.microstream.storage.types.StorageManager}.
+     * @return parameters name which should be stored in the associated {@link one.microstream.storage.types.StorageManager}.
      */
     String[] parameters() default {};
 

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
@@ -126,4 +126,17 @@ public @interface Store {
      * @return Whether to store the method result.
      */
     boolean result() default false;
+
+    /**
+     * The Storing strategy. Defaults to Lazy.
+     * @return Storing Strategy;
+     */
+    StoringStrategy strategy() default StoringStrategy.LAZY;
+
+    /**
+     * Whether to ignore {@link Store#parameters()} and {@link Store#result()} and store the whole entity class root. Defaults to false.
+     *
+     * @return  Whether to ignore {@link Store#parameters()} and {@link Store#result()} and store the whole entity class root.
+     */
+    boolean root() default false;
 }

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
@@ -82,4 +82,10 @@ public @interface Store {
      * @return parameters name which should be stored in the associated embeddded storage manager.
      */
     String[] parameters() default {};
+
+    /**
+     *
+     * @return Whether to store result.
+     */
+    boolean result() default false;
 }

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/Store.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotation;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation will wrap the decorated method to ensure thread isolation, and call storeAll on
+ * the updated graph. The return value of the wrapped method will be retained.
+ * <p>
+ * A method such as this:
+ * <pre>
+ * {@literal @Store}
+ *  public String set(){
+ *      root.changeData();
+ *  }
+ * </pre>
+ * <p>
+ * Will be decorated to become:
+ * <pre>
+ * {@literal @Store}
+ *  public String set() {
+ *      XThreads.executeSynchronized(() -> {
+ *          root.changeData();
+ *          manager.storeAll();
+ *      });
+ *  }
+ * </pre>
+ *
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @since 1.0.0
+ * @author Tim Yates
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+@Around
+public @interface Store {
+
+    /**
+     * The optional name qualifier of the store to use.
+     * If your application only have a Microstream instance, this is not required
+     *
+     * @return The name of the store
+     */
+    @AliasFor(member = "name")
+    String value() default "";
+
+    /**
+     * The optional name qualifier of the store to use.
+     * If your application only have a Microstream instance, this is not required
+     *
+     * @return The name of the store
+     */
+    @AliasFor(member = "value")
+    String name() default "";
+
+    /**
+     *
+     * @return parameters name which should be stored in the associated embeddded storage manager.
+     */
+    String[] parameters() default {};
+}

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
@@ -30,7 +30,11 @@ import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
 import one.microstream.concurrency.XThreads;
+import one.microstream.persistence.types.PersistenceStoring;
+import one.microstream.persistence.types.Storer;
 import one.microstream.storage.types.StorageManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Method interceptor for {@link Store}.
@@ -50,12 +56,14 @@ import java.util.concurrent.ConcurrentHashMap;
 @Singleton
 @InterceptorBean(Store.class)
 public class StoreInterceptor implements MethodInterceptor<Object, Object> {
+    private static final Logger LOG = LoggerFactory.getLogger(StoreInterceptor.class);
 
-    public static final String MULTIPLE_MANAGERS_WITH_NO_QUALIFIER_MESSAGE = "Multiple storage managers found, but no name was specified.";
-
+    private static final String MULTIPLE_MANAGERS_WITH_NO_QUALIFIER_MESSAGE = "Multiple storage managers found, but no name was specified.";
     private static final String DEFAULT_SINGLE_MANAGER_KEY = "__default__";
     private static final String PARAMETERS = "parameters";
     private static final String RESULT = "result";
+    private static final String STRATEGY = "strategy";
+    private static final String ROOT = "root";
 
     private final ConcurrentHashMap<String, StorageManager> managerLookup = new ConcurrentHashMap<>();
     private final BeanContext beanContext;
@@ -94,18 +102,65 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
                        @NonNull MethodInvocationContext<Object, Object> context,
                        @NonNull AnnotationValue<Store> storeAnnotationValue,
                        @Nullable Object result) {
-        List<Object> objects = targetParametersValues(context, storeAnnotationValue);
-        if (result != null && storeAnnotationValue.booleanValue(RESULT).orElse(false)) {
-            objects.add(result);
-        }
-        if (CollectionUtils.isNotEmpty(objects)) {
-            store(storageManager, objects);
+        if (storeAnnotationValue.booleanValue(ROOT).orElse(false)) {
+            storeRoot(storeAnnotationValue, storageManager);
+        } else {
+            List<Object> objects = targetParametersValues(context, storeAnnotationValue);
+            if (result != null && storeAnnotationValue.booleanValue(RESULT).orElse(false)) {
+                objects.add(result);
+            }
+            if (CollectionUtils.isNotEmpty(objects)) {
+                store(storeAnnotationValue, storageManager, objects);
+            }
         }
     }
 
-    private void store(@NonNull StorageManager storageManager,
+    private static void store(@NonNull AnnotationValue<Store> storeAnnotationValue,
+                              @NonNull StorageManager storageManager,
+                              @NonNull Consumer<Storer> eagerConsumer,
+                              @NonNull Runnable lazyRunnable) {
+        StoringStrategy storingStrategy = storeAnnotationValue.enumValue(STRATEGY, StoringStrategy.class)
+            .orElse(StoringStrategy.LAZY);
+        store(storingStrategy, storageManager, eagerConsumer, lazyRunnable);
+    }
+
+    private static void store(@NonNull StoringStrategy storingStrategy,
+                              @NonNull StorageManager storageManager,
+                              @NonNull Consumer<Storer> eagerConsumer,
+                              @NonNull Runnable lazyRunnable) {
+        switch (storingStrategy) {
+            case EAGER:
+                Storer storer = storageManager.createEagerStorer();
+                eagerConsumer.accept(storer);
+                storer.commit();
+                break;
+            case LAZY:
+            default:
+                lazyRunnable.run();
+        }
+    }
+
+    private static void storeRoot(@NonNull AnnotationValue<Store> storeAnnotationValue,
+                                  @NonNull StorageManager storageManager) {
+        final Object root   = storageManager.root();
+        store(storeAnnotationValue, storageManager,
+            storer -> storeRootObject(root, storer),
+            () -> storeRootObject(root, storageManager));
+    }
+
+    private static void store(@NonNull AnnotationValue<Store> storeAnnotationValue,
+                       @NonNull StorageManager storageManager,
                        @NonNull List<Object> instances) {
-        storageManager.storeAll(instances);
+        store(storeAnnotationValue, storageManager,
+            storer -> storeAll(storer, instances),
+            () -> storeAll(storageManager, instances));
+    }
+
+    private static void storeAll(@NonNull PersistenceStoring storing,
+                          @NonNull List<Object> instances) {
+        for (Object instance : instances) {
+            storing.store(instance);
+        }
     }
 
     @NonNull
@@ -144,7 +199,7 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
     }
 
     @NonNull
-    private static Map<String, MutableArgumentValue<?>> targetParamters(@NonNull MethodInvocationContext<Object, Object> context,
+    private static Map<String, MutableArgumentValue<?>> targetParameters(@NonNull MethodInvocationContext<Object, Object> context,
                                                                         @NonNull AnnotationValue<Store> storeAnnotationValue) {
         Map<String, MutableArgumentValue<?>> parameters = context.getParameters();
         Map<String, MutableArgumentValue<?>> targetParameters = new HashMap<>();
@@ -160,7 +215,7 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
     @NonNull
     private static List<Object> targetParametersValues(@NonNull MethodInvocationContext<Object, Object> context,
                                                        @NonNull AnnotationValue<Store> storeAnnotationValue) {
-        Map<String, MutableArgumentValue<?>> params = targetParamters(context, storeAnnotationValue);
+        Map<String, MutableArgumentValue<?>> params = targetParameters(context, storeAnnotationValue);
         List<Object> result = new ArrayList<>();
         for (Map.Entry<String, MutableArgumentValue<?>> entry : params.entrySet()) {
             MutableArgumentValue<?> argumentValue = entry.getValue();
@@ -172,4 +227,11 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
         return result;
     }
 
+    private static void storeRootObject(final Object root, final PersistenceStoring storing) {
+        final long storeId = storing.store(root);
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Store the root it might return performance issue {}", storeId);
+        }
+
+    }
 }

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * Method interceptor for {@link Store}.

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/StoreInterceptor.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotation;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.MutableArgumentValue;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.inject.Singleton;
+import one.microstream.concurrency.XThreads;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+@Singleton
+@InterceptorBean(Store.class)
+public class StoreInterceptor implements MethodInterceptor<Object, Object> {
+
+    public static final String MULTIPLE_MANAGERS_WITH_NO_QUALIFIER_MESSAGE = "Multiple storage managers found, but no name was specified.";
+
+    private static final String DEFAULT_SINGLE_MANAGER_KEY = "__default__";
+
+    private final ConcurrentHashMap<String, EmbeddedStorageManager> managerLookup = new ConcurrentHashMap<>();
+    private final BeanContext beanContext;
+
+    public StoreInterceptor(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @Nullable
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        AnnotationValue<Store> storeAnnotationValue = context.getAnnotation(Store.class);
+        if (storeAnnotationValue == null) {
+            return context.proceed();
+        }
+        @SuppressWarnings("resource") // We don't want to close the storage manager
+        EmbeddedStorageManager manager = lookupManager(storeAnnotationValue);
+
+        InterceptedMethod interceptedMethod = InterceptedMethod.of(context);
+        switch (interceptedMethod.resultType()) {
+            case PUBLISHER:
+                return interceptedMethod.handleResult(Flux.from(interceptedMethod.interceptResultAsPublisher())
+                    .doOnComplete(() -> {
+
+                    })
+                );
+            case COMPLETION_STAGE:
+                return interceptedMethod.interceptResultAsCompletionStage()
+                    .whenComplete((o, t) -> {
+
+                    });
+            case SYNCHRONOUS:
+                Object result = context.proceed();
+                List<Object> objects = targetParametersValues(context, storeAnnotationValue);
+                if (CollectionUtils.isNotEmpty(objects)) {
+                    store(manager, objects);
+                }
+                return result;
+            default:
+                return interceptedMethod.unsupported();
+        }
+    }
+
+    private void store(@NonNull EmbeddedStorageManager embeddedStorageManager,
+                       @NonNull List<Object> instances) {
+        XThreads.executeSynchronized(() -> {
+           embeddedStorageManager.storeAll(instances);
+        });
+    }
+
+    @NonNull
+    private EmbeddedStorageManager lookupManager(@NonNull AnnotationValue<Store> storeAnnotationValue) {
+        String name = Optional.ofNullable(storeAnnotationValue)
+            .flatMap(a -> a.stringValue("name")).orElse(null);
+        return lookupManager(name);
+    }
+
+    @NonNull
+    private EmbeddedStorageManager lookupManager(@Nullable String name) {
+        if (StringUtils.isNotEmpty(name)) {
+            return managerLookup.computeIfAbsent(name, this::getManagerForName);
+        } else {
+            return managerLookup.computeIfAbsent(DEFAULT_SINGLE_MANAGER_KEY, ignored -> getSingleManager());
+        }
+    }
+
+    @NonNull
+    private EmbeddedStorageManager getSingleManager() {
+        Collection<BeanDefinition<EmbeddedStorageManager>> beansOfType = beanContext.getBeanDefinitions(EmbeddedStorageManager.class);
+        if (beansOfType.size() != 1) {
+            throw new IllegalStateException(MULTIPLE_MANAGERS_WITH_NO_QUALIFIER_MESSAGE);
+        } else {
+            return beanContext.getBean(beansOfType.iterator().next());
+        }
+    }
+
+    @NonNull
+    private EmbeddedStorageManager getManagerForName(@NonNull String name) {
+        if (beanContext.containsBean(EmbeddedStorageManager.class, Qualifiers.byName(name))) {
+            return beanContext.getBean(EmbeddedStorageManager.class, Qualifiers.byName(name));
+        } else {
+            throw new StorageInterceptorException("No storage manager found for @" + Store.class.getSimpleName() + "(name = \"" + name + "\").");
+        }
+    }
+
+    @NonNull
+    private static Map<String, MutableArgumentValue<?>> targetParamters(@NonNull MethodInvocationContext<Object, Object> context,
+                                                                        @NonNull AnnotationValue<Store> storeAnnotationValue) {
+        Map<String, MutableArgumentValue<?>> parameters = context.getParameters();
+        Map<String, MutableArgumentValue<?>> targetParameters = new HashMap<>();
+        String[] storeAnnotationValueParameters = storeAnnotationValue.stringValues("parameters");
+        for (String key : parameters.keySet()) {
+            if (Arrays.stream(storeAnnotationValueParameters).anyMatch(it -> it.equalsIgnoreCase(key))) {
+                targetParameters.put(key, parameters.get(key));
+            }
+        }
+        return targetParameters;
+    }
+
+    @NonNull
+    private static List<Object> targetParametersValues(@NonNull MethodInvocationContext<Object, Object> context,
+                                                       @NonNull AnnotationValue<Store> storeAnnotationValue) {
+        Map<String, MutableArgumentValue<?>> params = targetParamters(context, storeAnnotationValue);
+        List<Object> result = new ArrayList<>();
+        for (String key : params.keySet()) {
+            MutableArgumentValue<?> argumentValue = params.get(key);
+            Object obj = argumentValue.getValue();
+            result.add(obj);
+        }
+        return result;
+    }
+
+}

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/StoringStrategy.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/StoringStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.annotation;
+
+/**
+ * Defines the way the instance that will be stored in the {@link one.microstream.storage.types.StorageManager}.
+ * <a href="https://docs.microstream.one/manual/storage/storing-data/lazy-eager-full.html">Lazy and Eager Storing</a>
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+public enum StoringStrategy {
+    /**
+     * Lazy storing is the default storing mode of the MicroStream engine.
+     * Referenced instances are stored only if they have not been stored yet.
+     * If a referenced instance has been stored previously it is not stored again even if it has been modified.
+     * That’s why modified objects must be stored explicitly.
+     */
+    LAZY,
+    /**
+     * In eager storing mode referenced instances are stored even if they had been stored before.
+     * Contrary to Lazy storing this will also store modified child objects at the cost of performance.
+     */
+    EAGER;
+}

--- a/microstream/src/main/java/io/micronaut/microstream/annotation/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/annotation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Packages relates to Microstream annotations.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+package io.micronaut.microstream.annotation;

--- a/microstream/src/main/java/io/micronaut/microstream/conf/StorageManagerFactory.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/StorageManagerFactory.java
@@ -26,6 +26,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
 import one.microstream.storage.embedded.types.EmbeddedStorageFoundation;
 import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +35,8 @@ import org.slf4j.LoggerFactory;
  * @since 1.0.0
  */
 @Factory
-public class EmbeddedStorageManagerFactory {
-    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedStorageManagerFactory.class);
+public class StorageManagerFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(StorageManagerFactory.class);
 
     private final BeanContext beanContext;
 
@@ -43,7 +44,7 @@ public class EmbeddedStorageManagerFactory {
      * Constructor.
      * @param beanContext Bean Context.
      */
-    public EmbeddedStorageManagerFactory(BeanContext beanContext) {
+    public StorageManagerFactory(BeanContext beanContext) {
         this.beanContext = beanContext;
     }
 
@@ -56,8 +57,8 @@ public class EmbeddedStorageManagerFactory {
     @EachBean(EmbeddedStorageFoundation.class)
     @Bean(preDestroy = "shutdown")
     @Singleton
-    public EmbeddedStorageManager createEmbeddedStorageManager(EmbeddedStorageFoundation<?> foundation,
-                                                               @Parameter String name) {
+    public StorageManager createStorageManager(EmbeddedStorageFoundation<?> foundation,
+                                                       @Parameter String name) {
         EmbeddedStorageManager storageManager = foundation.createEmbeddedStorageManager().start();
         if (storageManager.root() == null) {
             if (LOG.isTraceEnabled()) {

--- a/microstream/src/main/java/io/micronaut/microstream/conf/StorageManagerFactory.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/StorageManagerFactory.java
@@ -59,6 +59,7 @@ public class StorageManagerFactory {
     @Singleton
     public StorageManager createStorageManager(EmbeddedStorageFoundation<?> foundation,
                                                        @Parameter String name) {
+        @SuppressWarnings("resource") // We don't want to close the storage manager
         EmbeddedStorageManager storageManager = foundation.createEmbeddedStorageManager().start();
         if (storageManager.root() == null) {
             if (LOG.isTraceEnabled()) {

--- a/microstream/src/main/java/io/micronaut/microstream/health/MicrostreamHealthIndicator.java
+++ b/microstream/src/main/java/io/micronaut/microstream/health/MicrostreamHealthIndicator.java
@@ -17,6 +17,7 @@ package io.micronaut.microstream.health;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.health.HealthStatus;
@@ -25,7 +26,8 @@ import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import jakarta.inject.Singleton;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageActivePart;
+import one.microstream.storage.types.StorageManager;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -33,7 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * A {@link HealthIndicator} that checks the health of all registered {@link EmbeddedStorageManager}s.
+ * A {@link HealthIndicator} that checks the health of all registered {@link StorageManager}s.
  *
  * @since 1.0.0
  * @author Tim Yates
@@ -45,33 +47,38 @@ public class MicrostreamHealthIndicator implements HealthIndicator {
 
     public static final String MICROSTREAM_PREFIX = "microstream";
     private static final String DOT = ".";
-    private final Map<String, EmbeddedStorageManager> embeddedStorageManagerMap = new ConcurrentHashMap<>();
+    private final Map<String, StorageManager> storageManagerMap = new ConcurrentHashMap<>();
 
     public MicrostreamHealthIndicator(BeanContext beanContext) {
-        for (BeanDefinition<EmbeddedStorageManager> definition : beanContext.getBeanDefinitions(EmbeddedStorageManager.class)) {
+        for (BeanDefinition<StorageManager> definition : beanContext.getBeanDefinitions(StorageManager.class)) {
             if (definition.getDeclaredQualifier() instanceof Named) {
                 String name = ((Named) definition.getDeclaredQualifier()).getName();
-                EmbeddedStorageManager embeddedStorageManager = beanContext.getBean(definition);
-                embeddedStorageManagerMap.putIfAbsent(name, embeddedStorageManager);
+                StorageManager storageManager = beanContext.getBean(definition);
+                storageManagerMap.putIfAbsent(name, storageManager);
             }
         }
     }
 
     @Override
     public Publisher<HealthResult> getResult() {
-        return Flux.fromIterable(embeddedStorageManagerMap.entrySet())
+        return Flux.fromIterable(storageManagerMap.entrySet())
             .map(namedBean -> {
-                EmbeddedStorageManager manager = namedBean.getValue();
+                StorageManager manager = namedBean.getValue();
                 return HealthResult.builder(
                         String.join(DOT, MICROSTREAM_PREFIX, namedBean.getKey()),
-                        namedBean.getValue().isRunning() ? HealthStatus.UP : HealthStatus.DOWN
-                    ).details(new MicrostreamHealth(manager.isStartingUp(),
-                        manager.isRunning(),
-                        manager.isActive(),
-                        manager.isAcceptingTasks(),
-                        manager.isShuttingDown(),
-                        manager.isShutdown()))
+                        namedBean.getValue().isRunning() ? HealthStatus.UP : HealthStatus.DOWN)
+                    .details(healthOfManager(manager))
                     .build();
             });
+    }
+
+    @NonNull
+    private static MicrostreamHealth healthOfManager(@NonNull StorageManager manager) {
+        return new MicrostreamHealth(manager.isStartingUp(),
+            manager.isRunning(),
+            manager.isActive(),
+            manager.isAcceptingTasks(),
+            manager.isShuttingDown(),
+            manager.isShutdown());
     }
 }

--- a/microstream/src/main/java/io/micronaut/microstream/health/MicrostreamHealthIndicator.java
+++ b/microstream/src/main/java/io/micronaut/microstream/health/MicrostreamHealthIndicator.java
@@ -26,7 +26,6 @@ import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import jakarta.inject.Singleton;
-import one.microstream.storage.types.StorageActivePart;
 import one.microstream.storage.types.StorageManager;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/StorageInterceptorException.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/StorageInterceptorException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.microstream.annotation;
+package io.micronaut.microstream.interceptors;
 
 /**
  * Exception thrown when an error occurs during storage interceptor processing.

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
@@ -233,6 +233,5 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
         if (LOG.isWarnEnabled()) {
             LOG.warn("Store the root it might return performance issue {}", storeId);
         }
-
     }
 }

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
@@ -166,7 +166,7 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
 
     @NonNull
     private StorageManager lookupManager(@NonNull AnnotationValue<Store> storeAnnotationValue) {
-        String name = Optional.ofNullable(storeAnnotationValue)
+        String name = Optional.of(storeAnnotationValue)
             .flatMap(a -> a.stringValue("name")).orElse(null);
         return lookupManager(name);
     }

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.microstream.annotation;
+package io.micronaut.microstream.interceptors;
 
 import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBean;
@@ -28,6 +28,8 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoringStrategy;
 import jakarta.inject.Singleton;
 import one.microstream.concurrency.XThreads;
 import one.microstream.persistence.types.PersistenceStoring;

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/StoreInterceptor.java
@@ -231,7 +231,7 @@ public class StoreInterceptor implements MethodInterceptor<Object, Object> {
     private static void storeRootObject(final Object root, final PersistenceStoring storing) {
         final long storeId = storing.store(root);
         if (LOG.isWarnEnabled()) {
-            LOG.warn("Store the root it might return performance issue {}", storeId);
+            LOG.warn("Storing the root object may result in performance issues {}", storeId);
         }
     }
 }

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Class related to interceptors to provide functionality for the Microstream annotations.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+package io.micronaut.microstream.interceptors;

--- a/microstream/src/main/java/io/micronaut/microstream/metrics/MicrostreamMetricsBinder.java
+++ b/microstream/src/main/java/io/micronaut/microstream/metrics/MicrostreamMetricsBinder.java
@@ -28,7 +28,8 @@ import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import jakarta.inject.Singleton;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -56,29 +57,29 @@ public class MicrostreamMetricsBinder implements MeterBinder {
     private static final String DESCRIPTION_LIVE_DATA_LENGTH = "Displays live data length. This is the 'real' size of the stored data.";
     private static final String DOT = ".";
 
-    private final Map<String, EmbeddedStorageManager> embeddedStorageManagerMap = new ConcurrentHashMap<>();
+    private final Map<String, StorageManager> storageManagerMap = new ConcurrentHashMap<>();
 
     /**
      *
      * @param beanContext Bean Context
      */
     public MicrostreamMetricsBinder(BeanContext beanContext) {
-        for (BeanDefinition<EmbeddedStorageManager> definition : beanContext.getBeanDefinitions(EmbeddedStorageManager.class)) {
+        for (BeanDefinition<StorageManager> definition : beanContext.getBeanDefinitions(StorageManager.class)) {
             if (definition.getDeclaredQualifier() instanceof Named) {
-                EmbeddedStorageManager embeddedStorageManager = beanContext.getBean(definition);
-                embeddedStorageManagerMap.putIfAbsent(((Named) definition.getDeclaredQualifier()).getName(), embeddedStorageManager);
+                StorageManager storageManager = beanContext.getBean(definition);
+                storageManagerMap.putIfAbsent(((Named) definition.getDeclaredQualifier()).getName(), storageManager);
             }
         }
     }
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        embeddedStorageManagerMap.forEach((key, value) ->
-            bindEmbeddedStorageManagerToRegistry(key, value, registry));
+        storageManagerMap.forEach((key, value) ->
+            bindStorageManagerToRegistry(key, value, registry));
     }
 
-    private void bindEmbeddedStorageManagerToRegistry(@NonNull String name,
-                                                      @NonNull EmbeddedStorageManager manager,
+    private void bindStorageManagerToRegistry(@NonNull String name,
+                                                      @NonNull StorageManager manager,
                                                       @NonNull MeterRegistry registry) {
         gauge(registry, name, SUFFIX_TOTAL_DATA_LENGTH,
             DESCRIPTION_TOTAL_DATA_LENGTH,

--- a/microstream/src/main/java/io/micronaut/microstream/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Class related to Microstream integration with the Micronaut Framework.
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+package io.micronaut.microstream;

--- a/microstream/src/test/groovy/io/micronaut/microstream/DefaultRootProviderSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/DefaultRootProviderSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.microstream
+
+import io.micronaut.microstream.health.MicrostreamHealth
+import one.microstream.storage.types.StorageManager
+import spock.lang.Specification
+
+class DefaultRootProviderSpec extends Specification {
+
+    void "DefaultRootProvider casts StoreManager::root"() {
+        def storageManager = Stub(StorageManager) {
+            root() >> new MicrostreamHealth(false, true, true, false, false, false)
+        }
+        expect:
+        new DefaultRootProvider<>(storageManager).root() instanceof MicrostreamHealth
+    }
+}

--- a/microstream/src/test/groovy/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactorySpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactorySpec.groovy
@@ -1,8 +1,6 @@
 package io.micronaut.microstream.conf
 
 import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Property
-import io.micronaut.core.util.StringUtils
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider

--- a/microstream/src/test/groovy/io/micronaut/microstream/conf/EmbeddedStorageManagerFactorySpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/conf/EmbeddedStorageManagerFactorySpec.groovy
@@ -6,13 +6,13 @@ import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.TempDir
 
 @MicronautTest(startApplication = false)
-class EmbeddedStorageManagerFactorySpec extends Specification implements TestPropertyProvider {
+class StorageManagerFactorySpec extends Specification implements TestPropertyProvider {
 
     @Inject
     BeanContext beanContext
@@ -31,12 +31,12 @@ class EmbeddedStorageManagerFactorySpec extends Specification implements TestPro
         ]
     }
 
-    void "you can have multiple beans of type EmbeddedStorageManager"() {
+    void "you can have multiple beans of type StorageManager"() {
         expect:
-        beanContext.getBeansOfType(EmbeddedStorageManager).size() == 2
+        beanContext.getBeansOfType(StorageManager).size() == 2
 
         when:
-        beanContext.getBean(EmbeddedStorageManager, Qualifiers.byName("blue"))
+        beanContext.getBean(StorageManager, Qualifiers.byName("blue"))
         then:
         noExceptionThrown()
     }

--- a/microstream/src/test/groovy/io/micronaut/microstream/health/MicrostreamHealthIndicatorFuncSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/health/MicrostreamHealthIndicatorFuncSpec.groovy
@@ -2,18 +2,14 @@ package io.micronaut.microstream.health
 
 import io.micronaut.context.BeanContext
 import io.micronaut.health.HealthStatus
-import io.micronaut.management.health.indicator.HealthResult
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
+import one.microstream.storage.types.StorageManager
 import reactor.test.StepVerifier
 import spock.lang.Specification
 import spock.lang.Unroll
-import java.util.function.Consumer
 
 @MicronautTest(startApplication = false)
 class MicrostreamHealthIndicatorFuncSpec extends Specification {
@@ -21,7 +17,7 @@ class MicrostreamHealthIndicatorFuncSpec extends Specification {
     @Inject
     BeanContext beanContext
 
-    EmbeddedStorageManager mockStorageManager = Mock()
+    StorageManager mockStorageManager = Mock()
 
     @Unroll
     void "#desc manager is #expectedStatus"() {
@@ -39,9 +35,9 @@ class MicrostreamHealthIndicatorFuncSpec extends Specification {
         HealthStatus.UP   | true      | 'running'
     }
 
-    @MockBean(bean = EmbeddedStorageManager, named = "mock-manager")
+    @MockBean(bean = StorageManager, named = "mock-manager")
     @Named("mock-manager")
-    EmbeddedStorageManager getEmbeddedStorageManager() {
+    StorageManager getStorageManager() {
         mockStorageManager
     }
 }

--- a/microstream/src/test/groovy/io/micronaut/microstream/interceptors/StoreInterceptorFuncTest.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/interceptors/StoreInterceptorFuncTest.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.microstream.interceptors
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.microstream.annotations.Store
+import io.micronaut.microstream.annotations.StoringStrategy
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import one.microstream.persistence.types.Storer
+import one.microstream.storage.types.StorageManager
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+@Property(name = "spec.name", value = "StoreInterceptorFuncTest")
+class StoreInterceptorFuncTest extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    Storer mockStorer = Mock()
+
+    StorageManager mockStorageManager = Mock() {
+        createEagerStorer() >> mockStorer
+    }
+
+    void "no name specified results in an exception"() {
+        given:
+        beanContext.registerSingleton(StorageManager, mockStorageManager, Qualifiers.byName('flowers'))
+        SpecController controller = beanContext.getBean(SpecController)
+
+        when:
+        controller.eagerResultantStore('iris')
+
+        then:
+        controller.called
+
+        and: "eager storage calls the storer directly"
+        1 * mockStorer.store("iris") >> 1L
+
+        when:
+        controller.called = false
+        controller.lazyResultantStore('spoon')
+
+        then:
+        controller.called
+
+        and: "lazy storage stores on the manager"
+        1 * mockStorageManager.store("spoon") >> 1L
+    }
+
+    @MockBean(bean = StorageManager, named = "flowers")
+    StorageManager getEmbeddedStorageManager() {
+        mockStorageManager
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "StoreInterceptorFuncTest")
+    static class SpecController {
+
+        boolean called = false;
+
+        @Store(name = "flowers", result = true, strategy = StoringStrategy.EAGER)
+        String eagerResultantStore(String flower) {
+            called = true
+            return flower
+        }
+
+        @Store(name = "flowers", result = true)
+        String lazyResultantStore(String flower) {
+            called = true
+            return flower
+        }
+    }
+}

--- a/microstream/src/test/groovy/io/micronaut/microstream/interceptors/StoreInterceptorFuncTest.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/interceptors/StoreInterceptorFuncTest.groovy
@@ -9,6 +9,7 @@ import io.micronaut.microstream.annotations.StoringStrategy
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import one.microstream.persistence.types.Storer
 import one.microstream.storage.types.StorageManager
@@ -21,9 +22,12 @@ class StoreInterceptorFuncTest extends Specification {
     @Inject
     BeanContext beanContext
 
+    List<String> data = []
+
     Storer mockStorer = Mock()
 
     StorageManager mockStorageManager = Mock() {
+        root() >> data
         createEagerStorer() >> mockStorer
     }
 
@@ -39,17 +43,41 @@ class StoreInterceptorFuncTest extends Specification {
         controller.called
 
         and: "eager storage calls the storer directly"
-        1 * mockStorer.store("iris") >> 1L
+        1 * mockStorer.store("iris")
+        1 * mockStorer.commit()
+        data == ["iris"]
 
         when:
         controller.called = false
-        controller.lazyResultantStore('spoon')
+        controller.lazyResultantStore('daisy')
 
         then:
         controller.called
 
         and: "lazy storage stores on the manager"
-        1 * mockStorageManager.store("spoon") >> 1L
+        1 * mockStorageManager.store("daisy")
+        data == ["iris", "daisy"]
+
+        when:
+        controller.called = false
+        controller.eagerRootStore('tulip')
+
+        then:
+        controller.called
+
+        and: "eager root storage stores on the storer directly with the full root object"
+        1 * mockStorer.store(["iris", "daisy", "tulip"])
+        1 * mockStorer.commit()
+
+        when:
+        controller.called = false
+        controller.lazyRootStore('rose')
+
+        then:
+        controller.called
+
+        and: "lazy root storage stores on the manager with the full root object"
+        1 * mockStorageManager.store(["iris", "daisy", "tulip", "rose"])
     }
 
     @MockBean(bean = StorageManager, named = "flowers")
@@ -61,18 +89,37 @@ class StoreInterceptorFuncTest extends Specification {
     @Requires(property = "spec.name", value = "StoreInterceptorFuncTest")
     static class SpecController {
 
+        StorageManager storageManager
         boolean called = false;
+
+        SpecController(@Named("flowers") StorageManager storageManager) {
+            this.storageManager = storageManager
+        }
 
         @Store(name = "flowers", result = true, strategy = StoringStrategy.EAGER)
         String eagerResultantStore(String flower) {
             called = true
+            storageManager.root() << flower
             return flower
         }
 
         @Store(name = "flowers", result = true)
         String lazyResultantStore(String flower) {
             called = true
+            storageManager.root() << flower
             return flower
+        }
+
+        @Store(name = "flowers", root = true, strategy = StoringStrategy.EAGER)
+        void eagerRootStore(String flower) {
+            called = true
+            storageManager.root() << flower
+        }
+
+        @Store(name = "flowers", root = true)
+        void lazyRootStore(String flower) {
+            called = true
+            storageManager.root() << flower
         }
     }
 }

--- a/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicrostreamMetricsBinderSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicrostreamMetricsBinderSpec.groovy
@@ -12,7 +12,7 @@ import jakarta.inject.Inject
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import one.microstream.concurrency.XThreads
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -84,12 +84,12 @@ class MicrostreamMetricsBinderSpec extends Specification implements TestProperty
     @Requires(property = "spec.name", value = "MicrostreamMetricsBinderSpec")
     static class SpecController {
 
-        private EmbeddedStorageManager townManager
-        private EmbeddedStorageManager peopleManager
+        private StorageManager townManager
+        private StorageManager peopleManager
 
         SpecController(
-                @Named('towns') EmbeddedStorageManager townManager,
-                @Named('people') EmbeddedStorageManager peopleManager
+                @Named('towns') StorageManager townManager,
+                @Named('people') StorageManager peopleManager
         ) {
             this.townManager = townManager
             this.peopleManager = peopleManager

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ plugins {
 
 rootProject.name = 'microstream-parent'
 
+include 'microstream-annotations'
 include 'microstream'
 include 'microstream-bom'
 include 'test-suite'

--- a/src/main/docs/guide/storage.adoc
+++ b/src/main/docs/guide/storage.adoc
@@ -1,3 +1,3 @@
-The following example shows how to create implementations for this example repository:
+The following example shows how to create implementations for this repository:
 
 snippet::io.micronaut.microstream.docs.CustomerRepository[]

--- a/src/main/docs/guide/storage/storageWithEmbeddedStorageManager.adoc
+++ b/src/main/docs/guide/storage/storageWithEmbeddedStorageManager.adoc
@@ -1,6 +1,6 @@
 The following example shows how to create a repository which injects the `EmbeddedStorageManager` and retrieves the Root Instance:
 
-snippet::io.micronaut.microstream.docs.CustomerRepositoryImpl[tags="clazz"]
+snippet::io.micronaut.microstream.docs.CustomerRepositoryImpl[tags=clazz]
 
 <1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `EmbeddedStorageManager`.
 <2> When you are https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data[working with Microstream technology in a multi-threaded environment],

--- a/src/main/docs/guide/storage/storageWithEmbeddedStorageManager.adoc
+++ b/src/main/docs/guide/storage/storageWithEmbeddedStorageManager.adoc
@@ -1,4 +1,4 @@
-The following example shows how to create a repository which injects the `EmbeddedStorageManager` and retrieve the Root Instance:
+The following example shows how to create a repository which injects the `EmbeddedStorageManager` and retrieves the Root Instance:
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryImpl[tags="clazz"]
 

--- a/src/main/docs/guide/storage/storageWithStorageManager.adoc
+++ b/src/main/docs/guide/storage/storageWithStorageManager.adoc
@@ -1,8 +1,8 @@
-The following example shows how to create a repository which injects the `EmbeddedStorageManager` and retrieves the Root Instance:
+The following example shows how to create a repository which injects the `StorageManager` and retrieves the Root Instance:
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryImpl[tags=clazz]
 
-<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `EmbeddedStorageManager`.
+<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `StorageManager`.
 <2> When you are https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data[working with Microstream technology in a multi-threaded environment],
 reading and writing to this shared object graph must be synchronized.
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -2,8 +2,8 @@ The following example shows how an equivalent implementation which leverages the
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 
-<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `EmbeddedStorageManager`.
+<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `StorageManager`.
 <2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 
-NOTE: ann:microstream.annotation.Store[] only works for synchronous methods. It does not do any logic for methods returning a `Publisher` or a `CompletableFuture`. For those scenarios, use directly the `EmbeddedStorageManager`.
+NOTE: ann:microstream.annotation.Store[] only works for synchronous methods. It does not do any logic for methods returning a `Publisher` or a `CompletableFuture`. For those scenarios, use directly the `StorageManager`.

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -6,3 +6,4 @@ snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 <2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 
+NOTE: ann:microstream.annotation.Store[] only works for synchronous methods. It does not do any logic for methods returning a `Publisher` or a `CompletableFuture`. For those scenarios, use directly the `EmbeddedStorageManager`.

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -1,6 +1,6 @@
 The following example shows how an equivalent implementation which leverages the ann:microstream.annotation.Store[] annotation to simplify object storage.
 
-snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags="clazz"]
+snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 
 <1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `EmbeddedStorageManager`.
 <2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -1,0 +1,8 @@
+The following example shows how an equivalent implementation which leverages the ann:microstream.annotation.Store[] annotation to simplify object storage.
+
+snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags="clazz"]
+
+<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `EmbeddedStorageManager`.
+<2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].
+<3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
+

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -3,7 +3,7 @@ The following example shows how an equivalent implementation which leverages the
 snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 
 <1> You can also inject an instance of api:microstream.RootProvider[] to easily access the Microstream Root Instance. If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject it.
-<2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].
+<2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!"].
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 
 NOTE: ann:microstream.annotation.Store[] only works for synchronous methods. It does not do any logic for methods returning a `Publisher` or a `CompletableFuture`. For those scenarios, use directly the `StorageManager`.

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -2,7 +2,7 @@ The following example shows how an equivalent implementation which leverages the
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 
-<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `StorageManager`.
+<1> You can also inject an instance of api:microstream.RootProvider[] to easily access the Microstream Root Instance. If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject it.
 <2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!".].
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,7 +6,7 @@ configuration: Configuration
 rootInstance: Root Instance
 storage:
   title: Storage
-  storageWithEmbeddedStorageManager: Embedded Storage Manager Store
+  storageWithStorageManager: StorageManager
   storageWithStore: Store Annotation
 microstreamMetrics: Metrics
 storageHealth: Health

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,7 +6,8 @@ configuration: Configuration
 rootInstance: Root Instance
 storage:
   title: Storage
-  storageWithEmbeddedStorageManager: Store with Embedded Storage Manager
+  storageWithEmbeddedStorageManager: Embedded Storage Manager Store
+  storageWithStore: Store Annotation
 microstreamMetrics: Metrics
 storageHealth: Health
 repository: Repository

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -6,10 +6,10 @@ repositories {
 }
 dependencies {
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    implementation(project(":microstream-annotations"))
 
     testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
 
+    testImplementation(project(":microstream-annotations"))
     testImplementation("io.micronaut:micronaut-validation")
     testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude module: 'groovy-all'

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -5,9 +5,11 @@ repositories {
     mavenCentral()
 }
 dependencies {
+    testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
+    implementation(project(":microstream-annotations"))
+
     testCompileOnly("io.micronaut:micronaut-inject-groovy:$micronautVersion")
 
-    testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testImplementation("io.micronaut:micronaut-validation")
     testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude module: 'groovy-all'

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerController.groovy
@@ -34,11 +34,12 @@ class CustomerController {
     }
 
     @Patch("/{id}")
-    MutableHttpResponse<?> update(@NonNull @NotNull @Valid @Body Customer customer) {
-        repository.update(customer)
+    MutableHttpResponse<?> update(@PathVariable @NonNull String id,
+                                  @NonNull @NotNull @Valid @Body CustomerSave customer) {
+        repository.update(id, customer)
         HttpResponse.ok()
                 .header(HttpHeaders.LOCATION, UriBuilder.of("/customer")
-                        .path(customer.getId())
+                        .path(id)
                         .build()
                         .toString())
     }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerController.groovy
@@ -1,12 +1,15 @@
 package io.micronaut.microstream.docs
 
 import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Patch
 import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Status
@@ -26,9 +29,18 @@ class CustomerController {
 
     @Post
     HttpResponse<?> save(@NonNull @NotNull @Valid @Body CustomerSave customerSave) {
-        Customer customer = new Customer(UUID.randomUUID().toString(), customerSave.firstName, customerSave.lastName)
-        repository.save(customer)
+        Customer customer = repository.save(customerSave)
         HttpResponse.created(UriBuilder.of("/customer").path(customer.id).build())
+    }
+
+    @Patch("/{id}")
+    MutableHttpResponse<?> update(@NonNull @NotNull @Valid @Body Customer customer) {
+        repository.update(customer)
+        HttpResponse.ok()
+                .header(HttpHeaders.LOCATION, UriBuilder.of("/customer")
+                        .path(customer.getId())
+                        .build()
+                        .toString())
     }
 
     @Get("/{id}")

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
@@ -19,7 +19,7 @@ class CustomerControllerSpec extends Specification {
     @Unroll
     void "verify CRUD with Microstream"(String customerRepositoryImplementation) {
         given:
-        String storageDirectory = "build/microstream-" + UUID.randomUUID();
+        String storageDirectory = "build/microstream-" + UUID.randomUUID()
         ServerAndClient server = startServer(serverProperties(storageDirectory, customerRepositoryImplementation))
 
         and:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
@@ -69,7 +69,7 @@ class CustomerControllerSpec extends Specification {
 
         when:
         String sergioLastName = "del Amo"
-        HttpResponse<?> patchResponse = server.client.exchange(HttpRequest.PATCH(sergioLocation, [id: customer.id, firstName: customer.firstName, lastName: sergioLastName]))
+        HttpResponse<?> patchResponse = server.client.exchange(HttpRequest.PATCH(sergioLocation, [firstName: customer.firstName, lastName: sergioLastName]))
 
         then:
         HttpStatus.OK == patchResponse.status()

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.microstream.docs
 
 import groovy.transform.Canonical
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
@@ -67,6 +68,25 @@ class CustomerControllerSpec extends Specification {
         }
 
         when:
+        String sergioLastName = "del Amo"
+        HttpResponse<?> patchResponse = server.client.exchange(HttpRequest.PATCH(sergioLocation, [id: customer.id, firstName: customer.firstName, lastName: sergioLastName]))
+
+        then:
+        HttpStatus.OK == patchResponse.status()
+        patchResponse.getHeaders().get(HttpHeaders.LOCATION)
+        sergioLocation == patchResponse.getHeaders().get(HttpHeaders.LOCATION)
+
+        when: 'When we restart the server and we re-retrieve Sergio'
+        server = startServer(serverProperties(storageDirectory, customerRepositoryImplementation), server)
+        customer = getCustomer(server.client, sergioLocation)
+
+        then: "fetch Sergio, he still exists"
+        with(customer) {
+            firstName == sergioName
+            lastName == sergioLastName
+        }
+
+        when:
         deleteCustomer(server.client, sergioLocation)
 
         and:
@@ -99,7 +119,7 @@ class CustomerControllerSpec extends Specification {
         server.close()
 
         where:
-        customerRepositoryImplementation << ["embedded-storage-manager"]
+        customerRepositoryImplementation << ["embedded-storage-manager", "store"]
     }
 
     private static Map<String, String> serverProperties(String storageDirectory, String customerRepositoryImplementation) {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
@@ -9,13 +9,13 @@ import javax.validation.constraints.NotNull
 interface CustomerRepository {
 
     @NonNull
-    Customer save(@NonNull @NotNull @Valid CustomerSave customer);
+    Customer save(@NonNull @NotNull @Valid CustomerSave customer)
 
     void update(@NonNull @NotBlank String id,
-                @NonNull @NotNull @Valid CustomerSave customer);
+                @NonNull @NotNull @Valid CustomerSave customer)
 
     @NonNull
-    Optional<Customer> findById(@NonNull @NotBlank String id);
+    Optional<Customer> findById(@NonNull @NotBlank String id)
 
-    void deleteById(@NonNull @NotBlank String id);
+    void deleteById(@NonNull @NotBlank String id)
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
@@ -8,10 +8,13 @@ import javax.validation.constraints.NotNull
 
 interface CustomerRepository {
 
-    void save(@NonNull @NotNull @Valid Customer customer)
+    @NonNull
+    Customer save(@NonNull @NotNull @Valid CustomerSave customer);
+
+    void update(@NonNull @NotNull @Valid Customer customer);
 
     @NonNull
-    Optional<Customer> findById(@NonNull @NotBlank String id)
+    Optional<Customer> findById(@NonNull @NotBlank String id);
 
-    void deleteById(@NonNull @NotBlank String id)
+    void deleteById(@NonNull @NotBlank String id);
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepository.groovy
@@ -11,7 +11,8 @@ interface CustomerRepository {
     @NonNull
     Customer save(@NonNull @NotNull @Valid CustomerSave customer);
 
-    void update(@NonNull @NotNull @Valid Customer customer);
+    void update(@NonNull @NotBlank String id,
+                @NonNull @NotNull @Valid CustomerSave customer);
 
     @NonNull
     Optional<Customer> findById(@NonNull @NotBlank String id);

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryImpl.groovy
@@ -37,13 +37,14 @@ class CustomerRepositoryImpl implements CustomerRepository {
     }
 
     @Override
-    void update(@NonNull @NotNull @Valid Customer customer) {
+    void update(@NonNull @NotBlank String id,
+                @NonNull @NotNull @Valid CustomerSave customerSave) {
         XThreads.executeSynchronized(new Runnable() { // <2>
             @Override
             void run() {
-                Customer c = data().getCustomers().get(customer.getId())
-                c.setFirstName(customer.getFirstName())
-                c.setLastName(customer.getLastName())
+                Customer c = data().getCustomers().get(id)
+                c.setFirstName(customerSave.getFirstName())
+                c.setLastName(customerSave.getLastName())
                 store(c) // <3>
             }
         })

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryImpl.groovy
@@ -4,7 +4,8 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import jakarta.inject.Singleton
 import one.microstream.concurrency.XThreads
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
+
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -15,10 +16,10 @@ import java.util.function.Supplier
 @Singleton
 class CustomerRepositoryImpl implements CustomerRepository {
 
-    private final EmbeddedStorageManager embeddedStorageManager
+    private final StorageManager storageManager
 
-    CustomerRepositoryImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
-        this.embeddedStorageManager = embeddedStorageManager
+    CustomerRepositoryImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager
     }
 
     @Override
@@ -68,11 +69,11 @@ class CustomerRepositoryImpl implements CustomerRepository {
     }
 
     private void store(Object instance) {
-        embeddedStorageManager.store(instance)
+        storageManager.store(instance)
     }
 
     private Data data() {
-        (Data) embeddedStorageManager.root()
+        (Data) storageManager.root()
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.microstream.docs
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.microstream.annotation.Store
+import jakarta.inject.Singleton
+import one.microstream.storage.embedded.types.EmbeddedStorageManager
+
+import javax.validation.Valid
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+@Requires(property = "customer.repository", value = "store")
+//tag::clazz[]
+@Singleton
+class CustomerRepositoryStoreImpl implements CustomerRepository {
+
+    private final EmbeddedStorageManager embeddedStorageManager
+
+    CustomerRepositoryStoreImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
+        this.embeddedStorageManager = embeddedStorageManager
+    }
+
+    @Override
+    @NonNull
+    Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
+        return addCustomer(data().getCustomers(), customerSave)
+    }
+
+    @Override
+    void update(@NonNull @NotNull @Valid Customer customer) {
+        updateCustomer(customer)
+    }
+
+    @Override
+    @NonNull
+    Optional<Customer> findById(@NonNull @NotBlank String id) {
+        Optional.ofNullable(data().getCustomers().get(id))
+    }
+
+    @Override
+    void deleteById(@NonNull @NotBlank String id) {
+        removeCustomer(data().getCustomers(), id)
+    }
+
+    @Store(result = true) // <2>
+    @Nullable
+    protected Customer updateCustomer(@NonNull Customer customer) {
+        Customer c = data().getCustomers().get(customer.getId())
+        if (c != null) {
+            c.setFirstName(customer.getFirstName())
+            c.setLastName(customer.getLastName())
+            return c
+        }
+        return null
+    }
+
+    @Store(parameters = "customers") // <3>
+    protected Customer addCustomer(@NonNull Map<String, Customer> customers,
+                                   @NonNull CustomerSave customerSave) {
+        Customer customer = new Customer(UUID.randomUUID().toString(),
+            customerSave.getFirstName(),
+            customerSave.getLastName())
+        customers.put(customer.getId(), customer)
+        customer
+    }
+
+    @Store(parameters = "customers") // <3>
+    protected void removeCustomer(@NonNull Map<String, Customer> customers,
+                                  @NonNull String id) {
+        customers.remove(id)
+    }
+
+    @NonNull
+    private Data data() {
+        (Data) embeddedStorageManager.root()
+    }
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.microstream.annotation.Store
 import jakarta.inject.Singleton
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
 
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
@@ -16,10 +16,10 @@ import javax.validation.constraints.NotNull
 @Singleton
 class CustomerRepositoryStoreImpl implements CustomerRepository {
 
-    private final EmbeddedStorageManager embeddedStorageManager
+    private final StorageManager storageManager
 
-    CustomerRepositoryStoreImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
-        this.embeddedStorageManager = embeddedStorageManager
+    CustomerRepositoryStoreImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager
     }
 
     @Override
@@ -78,7 +78,7 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
 
     @NonNull
     private Data data() {
-        (Data) embeddedStorageManager.root()
+        (Data) storageManager.root()
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
@@ -4,7 +4,9 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.microstream.RootProvider
-import io.micronaut.microstream.annotation.Store
+import io.micronaut.microstream.annotations.Store
+import io.micronaut.microstream.annotations.StoreParams
+import io.micronaut.microstream.annotations.StoreReturn
 import jakarta.inject.Singleton
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
@@ -44,7 +46,7 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
         removeCustomer(rootProvider.root().customers, id)
     }
 
-    @Store(result = true) // <2>
+    @StoreReturn // <2>
     @Nullable
     protected Customer updateCustomer(@NonNull String id,
                                       @NonNull CustomerSave customerSave) {
@@ -59,7 +61,7 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
         null
     }
 
-    @Store(parameters = "customers") // <3>
+    @StoreParams("customers") // <3>
     protected Customer addCustomer(@NonNull Map<String, Customer> customers,
                                    @NonNull CustomerSave customerSave) {
         Customer customer = new Customer(UUID.randomUUID().toString(),
@@ -69,7 +71,7 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
         customer
     }
 
-    @Store(parameters = "customers") // <3>
+    @StoreParams("customers") // <3>
     protected void removeCustomer(@NonNull Map<String, Customer> customers,
                                   @NonNull String id) {
         customers.remove(id)

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
@@ -3,10 +3,9 @@ package io.micronaut.microstream.docs
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.microstream.RootProvider
 import io.micronaut.microstream.annotation.Store
 import jakarta.inject.Singleton
-import one.microstream.storage.types.StorageManager
-
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -16,16 +15,16 @@ import javax.validation.constraints.NotNull
 @Singleton
 class CustomerRepositoryStoreImpl implements CustomerRepository {
 
-    private final StorageManager storageManager
+    private final RootProvider<Data> rootProvider
 
-    CustomerRepositoryStoreImpl(StorageManager storageManager) { // <1>
-        this.storageManager = storageManager
+    CustomerRepositoryStoreImpl(RootProvider<Data> rootProvider) { // <1>
+        this.rootProvider = rootProvider
     }
 
     @Override
     @NonNull
     Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
-        return addCustomer(data().getCustomers(), customerSave)
+        return addCustomer(rootProvider.root().customers, customerSave)
     }
 
     @Override
@@ -37,19 +36,19 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
     @Override
     @NonNull
     Optional<Customer> findById(@NonNull @NotBlank String id) {
-        Optional.ofNullable(data().getCustomers().get(id))
+        Optional.ofNullable(rootProvider.root().customers[id])
     }
 
     @Override
     void deleteById(@NonNull @NotBlank String id) {
-        removeCustomer(data().getCustomers(), id)
+        removeCustomer(rootProvider.root().customers, id)
     }
 
     @Store(result = true) // <2>
     @Nullable
     protected Customer updateCustomer(@NonNull String id,
                                       @NonNull CustomerSave customerSave) {
-        Customer c = data().getCustomers().get(id)
+        Customer c = rootProvider.root().customers[id]
         if (c != null) {
             c.with {
                 firstName = customerSave.firstName
@@ -74,11 +73,6 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
     protected void removeCustomer(@NonNull Map<String, Customer> customers,
                                   @NonNull String id) {
         customers.remove(id)
-    }
-
-    @NonNull
-    private Data data() {
-        (Data) storageManager.root()
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.groovy
@@ -29,8 +29,9 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
     }
 
     @Override
-    void update(@NonNull @NotNull @Valid Customer customer) {
-        updateCustomer(customer)
+    void update(@NonNull @NotBlank String id,
+                @NonNull @NotNull @Valid CustomerSave customerSave) {
+        updateCustomer(id, customerSave)
     }
 
     @Override
@@ -46,23 +47,26 @@ class CustomerRepositoryStoreImpl implements CustomerRepository {
 
     @Store(result = true) // <2>
     @Nullable
-    protected Customer updateCustomer(@NonNull Customer customer) {
-        Customer c = data().getCustomers().get(customer.getId())
+    protected Customer updateCustomer(@NonNull String id,
+                                      @NonNull CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id)
         if (c != null) {
-            c.setFirstName(customer.getFirstName())
-            c.setLastName(customer.getLastName())
+            c.with {
+                firstName = customerSave.firstName
+                lastName = customerSave.lastName
+            }
             return c
         }
-        return null
+        null
     }
 
     @Store(parameters = "customers") // <3>
     protected Customer addCustomer(@NonNull Map<String, Customer> customers,
                                    @NonNull CustomerSave customerSave) {
         Customer customer = new Customer(UUID.randomUUID().toString(),
-            customerSave.getFirstName(),
-            customerSave.getLastName())
-        customers.put(customer.getId(), customer)
+            customerSave.firstName,
+            customerSave.lastName)
+        customers[customer.id] = customer
         customer
     }
 

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -8,7 +8,11 @@ repositories {
 }
 
 dependencies {
+    kaptTest(platform("io.micronaut:micronaut-bom:$micronautVersion"))
+    kaptTest (project(":microstream-annotations"))
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
+    testImplementation(project(":microstream-annotations"))
+
     testImplementation("io.micronaut:micronaut-validation")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/Customer.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/Customer.kt
@@ -1,10 +1,6 @@
 package io.micronaut.microstream.docs
 
 import io.micronaut.core.annotation.Introspected
-import javax.validation.constraints.NotBlank
 
 @Introspected
-data class Customer(
-    @field:NotBlank var id: String,
-    @field:NotBlank var firstName: String,
-    var lastName: String?)
+class Customer(val id: String, var firstName: String, var lastName: String?)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerController.kt
@@ -1,34 +1,34 @@
 package io.micronaut.microstream.docs
 
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Status
-import io.micronaut.http.annotation.Delete
-import io.micronaut.http.annotation.Body
-import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.*
 import io.micronaut.http.uri.UriBuilder
-import java.util.UUID
 import javax.validation.Valid
+import javax.validation.constraints.NotNull
 
 @Controller("/customer")
 internal class CustomerController(private val repository: CustomerRepository) {
     @Post
     fun save(@Body customerSave: @Valid CustomerSave): HttpResponse<*> {
-        val customer = Customer(
-            UUID.randomUUID().toString(),
-            customerSave.firstName,
-            customerSave.lastName
-        )
-        repository.save(customer)
+        val customer = repository.save(customerSave)
         return HttpResponse.created<Any>(UriBuilder.of("/customer").path(customer.id).build())
     }
 
     @Get("/{id}")
     fun show(@PathVariable id: String): Customer? {
         return repository.findById(id)
+    }
+
+    @Patch("/{id}")
+    fun update(@Body customer: @Valid Customer): MutableHttpResponse<*>? {
+        repository.update(customer)
+        return HttpResponse.ok<Any>()
+            .header(HttpHeaders.LOCATION,
+                UriBuilder.of("/customer").path(customer.id).build().toString())
     }
 
     @Delete("/{id}")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerController.kt
@@ -1,14 +1,19 @@
 package io.micronaut.microstream.docs
 
-import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MutableHttpResponse
-import io.micronaut.http.annotation.*
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Patch
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Status
+import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.uri.UriBuilder
 import javax.validation.Valid
-import javax.validation.constraints.NotNull
 
 @Controller("/customer")
 internal class CustomerController(private val repository: CustomerRepository) {
@@ -24,11 +29,12 @@ internal class CustomerController(private val repository: CustomerRepository) {
     }
 
     @Patch("/{id}")
-    fun update(@Body customer: @Valid Customer): MutableHttpResponse<*>? {
-        repository.update(customer)
+    fun update(@PathVariable id: String,
+               @Body customer: @Valid CustomerSave): MutableHttpResponse<*>? {
+        repository.update(id, customer)
         return HttpResponse.ok<Any>()
             .header(HttpHeaders.LOCATION,
-                UriBuilder.of("/customer").path(customer.id).build().toString())
+                UriBuilder.of("/customer").path(id).build().toString())
     }
 
     @Delete("/{id}")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepository.kt
@@ -4,8 +4,8 @@ import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 
 interface CustomerRepository {
-    fun save(customer: @Valid CustomerSave): Customer
-    fun update(customer: @Valid Customer)
+    fun save(customerSave: @Valid CustomerSave): Customer
+    fun update(id: @NotBlank String, customerSave: @Valid CustomerSave)
     fun findById(id: @NotBlank String): Customer?
     fun deleteById(id: @NotBlank String)
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepository.kt
@@ -4,7 +4,8 @@ import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 
 interface CustomerRepository {
-    fun save(customer: @Valid Customer)
+    fun save(customer: @Valid CustomerSave): Customer
+    fun update(customer: @Valid Customer)
     fun findById(id: @NotBlank String): Customer?
     fun deleteById(id: @NotBlank String)
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.NonNull
 import jakarta.inject.Singleton
 import one.microstream.concurrency.XThreads
 import one.microstream.storage.embedded.types.EmbeddedStorageManager
-import javax.validation.Valid
+import java.util.*
 import javax.validation.constraints.NotBlank
 
 @Requires(property = "customer.repository", value = "embedded-storage-manager")
@@ -13,34 +13,43 @@ import javax.validation.constraints.NotBlank
 @Singleton
 class CustomerRepositoryImpl(private val embeddedStorageManager: EmbeddedStorageManager) // <1>
     : CustomerRepository {
-    override fun save(customer: @Valid Customer) {
-        XThreads.executeSynchronized { // <2>
-            if (data != null) {
-                data!!.customers[customer.id] = customer
-                embeddedStorageManager.store(data!!.customers) // <3>
-            }
+    override fun save(customerSave: CustomerSave): Customer {
+        val id = UUID.randomUUID().toString()
+        val customer = Customer(id, customerSave.firstName, customerSave.lastName)
+        XThreads.executeSynchronized {
+            data.customers[customer.id] = customer
+            embeddedStorageManager.store(data.customers) // <3>
+        }
+        return customer
+    }
 
+    override fun update(customer: Customer) {
+        XThreads.executeSynchronized { // <2>
+            val c: Customer? = data.customers[customer.id]
+            if (c != null) {
+                c.firstName = customer.firstName
+                c.lastName = customer.lastName
+                embeddedStorageManager.store(c) // <3>
+            }
         }
     }
 
     @NonNull
     override fun findById(id: @NotBlank String): Customer? {
-        return if (data != null) data!!.customers[id] else null
+        return data.customers[id]
     }
 
     override fun deleteById(id: @NotBlank String) {
         XThreads.executeSynchronized { // <2>
-            if (data != null) {
-                data!!.customers.remove(id)
-                embeddedStorageManager.store(data!!.customers) // <3>
-            }
+            data.customers.remove(id)
+            embeddedStorageManager.store(data.customers) // <3>
         }
     }
 
-    private val data: Data?
+    private val data: Data
         get() {
             val root = embeddedStorageManager.root()
-            return if (root is Data) root else null
+            return if (root is Data) root else throw RuntimeException("Root is not Data")
         }
 }
 //end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
@@ -16,20 +16,22 @@ class CustomerRepositoryImpl(private val embeddedStorageManager: EmbeddedStorage
     override fun save(customerSave: CustomerSave): Customer {
         val id = UUID.randomUUID().toString()
         val customer = Customer(id, customerSave.firstName, customerSave.lastName)
-        XThreads.executeSynchronized {
+        XThreads.executeSynchronized { // <2>
             data.customers[customer.id] = customer
             embeddedStorageManager.store(data.customers) // <3>
         }
         return customer
     }
 
-    override fun update(customer: Customer) {
+    override fun update(id : String, customerSave: CustomerSave) {
         XThreads.executeSynchronized { // <2>
-            val c: Customer? = data.customers[customer.id]
-            if (c != null) {
-                c.firstName = customer.firstName
-                c.lastName = customer.lastName
-                embeddedStorageManager.store(c) // <3>
+            val customer : Customer? = data.customers[id]
+            if (customer != null) {
+                with(customer) {
+                    firstName = customerSave.firstName
+                    lastName = customerSave.lastName
+                }
+                embeddedStorageManager.store(customer) // <3>
             }
         }
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryImpl.kt
@@ -4,21 +4,21 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import jakarta.inject.Singleton
 import one.microstream.concurrency.XThreads
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
 import java.util.*
 import javax.validation.constraints.NotBlank
 
 @Requires(property = "customer.repository", value = "embedded-storage-manager")
 //tag::clazz[]
 @Singleton
-class CustomerRepositoryImpl(private val embeddedStorageManager: EmbeddedStorageManager) // <1>
+class CustomerRepositoryImpl(private val storageManager: StorageManager) // <1>
     : CustomerRepository {
     override fun save(customerSave: CustomerSave): Customer {
         val id = UUID.randomUUID().toString()
         val customer = Customer(id, customerSave.firstName, customerSave.lastName)
         XThreads.executeSynchronized { // <2>
             data.customers[customer.id] = customer
-            embeddedStorageManager.store(data.customers) // <3>
+            storageManager.store(data.customers) // <3>
         }
         return customer
     }
@@ -31,7 +31,7 @@ class CustomerRepositoryImpl(private val embeddedStorageManager: EmbeddedStorage
                     firstName = customerSave.firstName
                     lastName = customerSave.lastName
                 }
-                embeddedStorageManager.store(customer) // <3>
+                storageManager.store(customer) // <3>
             }
         }
     }
@@ -44,13 +44,13 @@ class CustomerRepositoryImpl(private val embeddedStorageManager: EmbeddedStorage
     override fun deleteById(id: @NotBlank String) {
         XThreads.executeSynchronized { // <2>
             data.customers.remove(id)
-            embeddedStorageManager.store(data.customers) // <3>
+            storageManager.store(data.customers) // <3>
         }
     }
 
     private val data: Data
         get() {
-            val root = embeddedStorageManager.root()
+            val root = storageManager.root()
             return if (root is Data) root else throw RuntimeException("Root is not Data")
         }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
@@ -5,8 +5,7 @@ import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.microstream.annotation.Store
 import jakarta.inject.Singleton
-import one.microstream.concurrency.XThreads
-import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import one.microstream.storage.types.StorageManager
 import java.util.*
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
@@ -14,7 +13,7 @@ import javax.validation.constraints.NotBlank
 @Requires(property = "customer.repository", value = "store")
 //tag::clazz[]
 @Singleton
-open class CustomerRepositoryStoreImpl(private val embeddedStorageManager: EmbeddedStorageManager) // <1>
+open class CustomerRepositoryStoreImpl(private val storageManager: StorageManager) // <1>
     : CustomerRepository {
     override fun save(customerSave: @Valid CustomerSave): Customer {
         return addCustomer(data.customers, customerSave)
@@ -63,7 +62,7 @@ open class CustomerRepositoryStoreImpl(private val embeddedStorageManager: Embed
 
     private val data: Data
         get() {
-            val root = embeddedStorageManager.root()
+            val root = storageManager.root()
             return if (root is Data) root else throw RuntimeException("Root is not Data")
         }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
@@ -1,0 +1,70 @@
+package io.micronaut.microstream.docs
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.microstream.annotation.Store
+import jakarta.inject.Singleton
+import one.microstream.concurrency.XThreads
+import one.microstream.storage.embedded.types.EmbeddedStorageManager
+import java.util.*
+import javax.validation.Valid
+import javax.validation.constraints.NotBlank
+
+@Requires(property = "customer.repository", value = "store")
+//tag::clazz[]
+@Singleton
+open class CustomerRepositoryStoreImpl(private val embeddedStorageManager: EmbeddedStorageManager) // <1>
+    : CustomerRepository {
+    override fun save(customerSave: @Valid CustomerSave): Customer {
+        return addCustomer(data.customers, customerSave)
+    }
+
+    override fun update(id : @NotBlank String,
+                        customerSave: @Valid CustomerSave) {
+        updateCustomer(id, customerSave)
+    }
+
+    @NonNull
+    override fun findById(id: @NotBlank String): Customer? {
+        return data.customers[id]
+    }
+
+    override fun deleteById(id: @NotBlank String) {
+        removeCustomer(data.customers, id)
+    }
+
+    @Store(result = true) // <2>
+    @Nullable
+    open fun updateCustomer(id: String, customerSave: CustomerSave): Customer? {
+        val c: Customer? = data.customers[id]
+        return if (c != null) {
+            c.firstName = customerSave.firstName
+            c.lastName = customerSave.lastName
+            c
+        } else null
+    }
+
+    @Store(parameters = ["customers"]) // <3>
+    open fun addCustomer(customers: MutableMap<String, Customer>, customerSave: CustomerSave): Customer {
+        val customer = Customer(
+            UUID.randomUUID().toString(),
+            customerSave.firstName,
+            customerSave.lastName
+        )
+        customers[customer.id] = customer
+        return customer
+    }
+
+    @Store(parameters = ["customers"]) // <3>
+    open fun removeCustomer(customers: MutableMap<String, Customer>, id: String) {
+        customers.remove(id)
+    }
+
+    private val data: Data
+        get() {
+            val root = embeddedStorageManager.root()
+            return if (root is Data) root else throw RuntimeException("Root is not Data")
+        }
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
@@ -3,9 +3,9 @@ package io.micronaut.microstream.docs
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.microstream.RootProvider
 import io.micronaut.microstream.annotation.Store
 import jakarta.inject.Singleton
-import one.microstream.storage.types.StorageManager
 import java.util.*
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
@@ -13,10 +13,10 @@ import javax.validation.constraints.NotBlank
 @Requires(property = "customer.repository", value = "store")
 //tag::clazz[]
 @Singleton
-open class CustomerRepositoryStoreImpl(private val storageManager: StorageManager) // <1>
+open class CustomerRepositoryStoreImpl(private val rootProvider: RootProvider<Data>) // <1>
     : CustomerRepository {
     override fun save(customerSave: @Valid CustomerSave): Customer {
-        return addCustomer(data.customers, customerSave)
+        return addCustomer(rootProvider.root().customers, customerSave)
     }
 
     override fun update(id : @NotBlank String,
@@ -26,17 +26,17 @@ open class CustomerRepositoryStoreImpl(private val storageManager: StorageManage
 
     @NonNull
     override fun findById(id: @NotBlank String): Customer? {
-        return data.customers[id]
+        return rootProvider.root().customers[id]
     }
 
     override fun deleteById(id: @NotBlank String) {
-        removeCustomer(data.customers, id)
+        removeCustomer(rootProvider.root().customers, id)
     }
 
     @Store(result = true) // <2>
     @Nullable
     open fun updateCustomer(id: String, customerSave: CustomerSave): Customer? {
-        val c: Customer? = data.customers[id]
+        val c: Customer? = rootProvider.root().customers[id]
         return if (c != null) {
             c.firstName = customerSave.firstName
             c.lastName = customerSave.lastName
@@ -59,11 +59,5 @@ open class CustomerRepositoryStoreImpl(private val storageManager: StorageManage
     open fun removeCustomer(customers: MutableMap<String, Customer>, id: String) {
         customers.remove(id)
     }
-
-    private val data: Data
-        get() {
-            val root = storageManager.root()
-            return if (root is Data) root else throw RuntimeException("Root is not Data")
-        }
 }
 //end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.kt
@@ -4,7 +4,9 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.microstream.RootProvider
-import io.micronaut.microstream.annotation.Store
+import io.micronaut.microstream.annotations.Store
+import io.micronaut.microstream.annotations.StoreParams
+import io.micronaut.microstream.annotations.StoreReturn
 import jakarta.inject.Singleton
 import java.util.*
 import javax.validation.Valid
@@ -33,7 +35,7 @@ open class CustomerRepositoryStoreImpl(private val rootProvider: RootProvider<Da
         removeCustomer(rootProvider.root().customers, id)
     }
 
-    @Store(result = true) // <2>
+    @StoreReturn // <2>
     @Nullable
     open fun updateCustomer(id: String, customerSave: CustomerSave): Customer? {
         val c: Customer? = rootProvider.root().customers[id]
@@ -44,7 +46,7 @@ open class CustomerRepositoryStoreImpl(private val rootProvider: RootProvider<Da
         } else null
     }
 
-    @Store(parameters = ["customers"]) // <3>
+    @StoreParams("customers") // <3>
     open fun addCustomer(customers: MutableMap<String, Customer>, customerSave: CustomerSave): Customer {
         val customer = Customer(
             UUID.randomUUID().toString(),
@@ -55,7 +57,7 @@ open class CustomerRepositoryStoreImpl(private val rootProvider: RootProvider<Da
         return customer
     }
 
-    @Store(parameters = ["customers"]) // <3>
+    @StoreParams("customers") // <3>
     open fun removeCustomer(customers: MutableMap<String, Customer>, id: String) {
         customers.remove(id)
     }

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -5,11 +5,15 @@ repositories {
     mavenCentral()
 }
 dependencies {
+    testAnnotationProcessor(project(":microstream-annotations"))
+    implementation(project(":microstream-annotations"))
+
     testAnnotationProcessor(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
     testAnnotationProcessor("io.micronaut:micronaut-validation")
 
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
+    implementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testImplementation("io.micronaut:micronaut-validation")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CRM.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CRM.java
@@ -1,0 +1,12 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class CRM {
+    private Customers customers = new Customers();
+
+    public Customers getCustomers() {
+        return customers;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
@@ -1,31 +1,11 @@
 package io.micronaut.microstream.docs;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.microstream.annotations.Store;
-import io.micronaut.microstream.annotations.StoringStrategy;
-import jakarta.inject.Singleton;
-import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-@Singleton
-public class CrmCustomerService {
-
-    private final StorageManager storageManager;
-
-    public CrmCustomerService(StorageManager storageManager) {
-        this.storageManager = storageManager;
-    }
-
-    @Store(result = true, strategy = StoringStrategy.EAGER)
+public interface CrmCustomerService {
     @NonNull
-    public Customers save(@NonNull @NotNull @Valid Customer customer) {
-        data().getCustomers().getCustomersById().put(customer.getId(), customer);
-        return data().getCustomers();
-    }
-
-    private CRM data() {
-        return (CRM) storageManager.root();
-    }
+    Customers save(@NonNull @NotNull @Valid Customer customer);
 }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
@@ -25,7 +25,6 @@ public class CrmCustomerService {
         return data().getCustomers();
     }
 
-
     private CRM data() {
         return (CRM) storageManager.root();
     }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
@@ -1,8 +1,8 @@
 package io.micronaut.microstream.docs;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.microstream.annotation.Store;
-import io.micronaut.microstream.annotation.StoringStrategy;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoringStrategy;
 import jakarta.inject.Singleton;
 import one.microstream.storage.types.StorageManager;
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerService.java
@@ -1,0 +1,32 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotation.Store;
+import io.micronaut.microstream.annotation.StoringStrategy;
+import jakarta.inject.Singleton;
+import one.microstream.storage.types.StorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Singleton
+public class CrmCustomerService {
+
+    private final StorageManager storageManager;
+
+    public CrmCustomerService(StorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @Store(result = true, strategy = StoringStrategy.EAGER)
+    @NonNull
+    public Customers save(@NonNull @NotNull @Valid Customer customer) {
+        data().getCustomers().getCustomersById().put(customer.getId(), customer);
+        return data().getCustomers();
+    }
+
+
+    private CRM data() {
+        return (CRM) storageManager.root();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerServiceImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerServiceImpl.java
@@ -1,0 +1,34 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoringStrategy;
+import jakarta.inject.Singleton;
+import one.microstream.storage.types.StorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Requires(property = "spec.service", value = "store")
+@Singleton
+public class CrmCustomerServiceImpl implements CrmCustomerService {
+
+    private final StorageManager storageManager;
+
+    public CrmCustomerServiceImpl(StorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @Override
+    @Store(result = true, strategy = StoringStrategy.EAGER)
+    @NonNull
+    public Customers save(@NonNull @NotNull @Valid Customer customer) {
+        data().getCustomers().getCustomersById().put(customer.getId(), customer);
+        return data().getCustomers();
+    }
+
+    private CRM data() {
+        return (CRM) storageManager.root();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerServiceStoreReturnImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CrmCustomerServiceStoreReturnImpl.java
@@ -1,0 +1,35 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoreReturn;
+import io.micronaut.microstream.annotations.StoringStrategy;
+import jakarta.inject.Singleton;
+import one.microstream.storage.types.StorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Requires(property = "spec.service", value = "store-return")
+@Singleton
+public class CrmCustomerServiceStoreReturnImpl implements CrmCustomerService {
+
+    private final StorageManager storageManager;
+
+    public CrmCustomerServiceStoreReturnImpl(StorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @Override
+    @StoreReturn(strategy = StoringStrategy.EAGER)
+    @NonNull
+    public Customers save(@NonNull @NotNull @Valid Customer customer) {
+        data().getCustomers().getCustomersById().put(customer.getId(), customer);
+        return data().getCustomers();
+    }
+
+    private CRM data() {
+        return (CRM) storageManager.root();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotBlank;
 public class Customer {
     @NonNull
     @NotBlank
-	private String id;
+	private final String id;
 
     @NonNull
     @NotBlank
@@ -28,6 +28,14 @@ public class Customer {
     @NonNull
     public String getId() {
         return id;
+    }
+
+    public void setFirstName(@NonNull String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void setLastName(@Nullable String lastName) {
+        this.lastName = lastName;
     }
 
     @NonNull

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerController.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerController.java
@@ -36,11 +36,12 @@ class CustomerController {
     }
 
     @Patch("/{id}")
-    MutableHttpResponse<?> update(@NonNull @NotNull @Valid @Body Customer customer) {
-        repository.update(customer);
+    MutableHttpResponse<?> update(@PathVariable @NonNull String id,
+                                  @NonNull @NotNull @Valid @Body CustomerSave customer) {
+        repository.update(id, customer);
         return HttpResponse.ok()
             .header(HttpHeaders.LOCATION, UriBuilder.of("/customer")
-                .path(customer.getId())
+                .path(id)
                 .build().toString());
     }
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerController.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerController.java
@@ -1,12 +1,15 @@
 package io.micronaut.microstream.docs;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
@@ -28,11 +31,17 @@ class CustomerController {
 
     @Post
     HttpResponse<?> save(@NonNull @NotNull @Valid @Body CustomerSave customerSave) {
-        Customer customer = new Customer(UUID.randomUUID().toString(),
-            customerSave.getFirstName(),
-            customerSave.getLastName());
-        repository.save(customer);
+        Customer customer = repository.save(customerSave);
         return HttpResponse.created(UriBuilder.of("/customer").path(customer.getId()).build());
+    }
+
+    @Patch("/{id}")
+    MutableHttpResponse<?> update(@NonNull @NotNull @Valid @Body Customer customer) {
+        repository.update(customer);
+        return HttpResponse.ok()
+            .header(HttpHeaders.LOCATION, UriBuilder.of("/customer")
+                .path(customer.getId())
+                .build().toString());
     }
 
     @Get("/{id}")

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CustomerControllerTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"embedded-storage-manager", "store"})
+    @ValueSource(strings = {"embedded-storage-manager", "store", "store-with-name"})
     void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {
         // Given
         String storageDirectory = "build/microstream-" + UUID.randomUUID();

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -47,23 +47,9 @@ class CustomerControllerTest {
         String sergioLastName = "del Amo";
         String timFirstName = "Tim";
 
-        // When we create Sergio
-        HttpRequest<?> request = HttpRequest.POST("/customer", Collections.singletonMap("firstName", sergioFirstName));
-        HttpResponse<?> response = client.exchange(request);
-
-        // Then
-        assertEquals(HttpStatus.CREATED, response.status());
-        String sergioLocation = response.getHeaders().get(HttpHeaders.LOCATION);
-        assertNotNull(sergioLocation);
-
-        // When we create Tim
-        request = HttpRequest.POST("/customer", Collections.singletonMap("firstName", timFirstName));
-        response = client.exchange(request);
-        assertEquals(HttpStatus.CREATED, response.status());
-
-        // Then
-        String timLocation = response.getHeaders().get(HttpHeaders.LOCATION);
-        assertNotNull(timLocation);
+        // When we create Sergio and Tim
+        String sergioLocation = create(client, sergioFirstName);
+        String timLocation = create(client, timFirstName);
 
         // When we retrieve Sergio
         HttpRequest<?> showRequest = HttpRequest.GET(sergioLocation);
@@ -155,4 +141,14 @@ class CustomerControllerTest {
         fourthClient.close();
         embeddedServer.close();
     }
+
+    private static String create(BlockingHttpClient client, String firstName) {
+        HttpRequest<?> request = HttpRequest.POST("/customer", Collections.singletonMap("firstName", firstName));
+        HttpResponse<?> response = client.exchange(request);
+        assertEquals(HttpStatus.CREATED, response.status());
+        String location = response.getHeaders().get(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        return location;
+    }
+
 }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -94,7 +94,8 @@ class CustomerControllerTest {
         assertNull(customer.getLastName());
 
         // When
-        HttpResponse<?> patchResponse = secondClient.exchange(HttpRequest.PATCH(sergioLocation, CollectionUtils.mapOf("id", customer.getId(), "firstName", customer.getFirstName(), "lastName", sergioLastName)));
+        HttpResponse<?> patchResponse = secondClient.exchange(HttpRequest.PATCH(sergioLocation,
+            CollectionUtils.mapOf( "firstName", customer.getFirstName(), "lastName", sergioLastName)));
 
         // Then
         assertEquals(HttpStatus.OK, patchResponse.status());

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -1,7 +1,6 @@
 package io.micronaut.microstream.docs;
 
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
@@ -27,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CustomerControllerTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"embedded-storage-manager", "store", "store-with-name"})
+    @ValueSource(strings = {"embedded-storage-manager", "store", "store-with-name", "root-eager"})
     void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {
         // Given
         String storageDirectory = "build/microstream-" + UUID.randomUUID();

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -26,7 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CustomerControllerTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"embedded-storage-manager", "store", "store-with-name", "root-eager"})
+    @ValueSource(strings = {
+        "store",
+        "embedded-storage-manager",
+        "store-with-name",
+        "root-eager",
+        "store-annotation"
+    })
     void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {
         // Given
         String storageDirectory = "build/microstream-" + UUID.randomUUID();

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -27,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CustomerControllerTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"embedded-storage-manager"})
+    //@ValueSource(strings = {"embedded-storage-manager", "store"})
+    @ValueSource(strings = {"store"})
     void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {
         // Given
         String storageDirectory = "build/microstream-" + UUID.randomUUID();

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -31,6 +31,7 @@ class CustomerControllerTest {
         "embedded-storage-manager",
         "store-with-name",
         "root-eager",
+        "store-root-eager",
         "store-annotation"
     })
     void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepository.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepository.java
@@ -12,9 +12,10 @@ import java.util.UUID;
 public interface CustomerRepository {
 
     @NonNull
-    Customer save(@NonNull @NotNull @Valid CustomerSave customer);
+    Customer save(@NonNull @NotNull @Valid CustomerSave customerSave);
 
-    void update(@NonNull @NotNull @Valid Customer customer);
+    void update(@NonNull @NotBlank String id,
+                @NonNull @NotNull @Valid CustomerSave customerSave);
 
     @NonNull
     Optional<Customer> findById(@NonNull @NotBlank String id);

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepository.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepository.java
@@ -7,10 +7,14 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface CustomerRepository {
 
-	void save(@NonNull @NotNull @Valid Customer customer);
+    @NonNull
+    Customer save(@NonNull @NotNull @Valid CustomerSave customer);
+
+    void update(@NonNull @NotNull @Valid Customer customer);
 
     @NonNull
     Optional<Customer> findById(@NonNull @NotBlank String id);

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
@@ -36,11 +36,12 @@ public class CustomerRepositoryImpl implements CustomerRepository {
 	}
 
     @Override
-    public void update(@NonNull @NotNull @Valid Customer customer) {
+    public void update(@NonNull @NotBlank String id,
+                       @NonNull @NotNull @Valid CustomerSave customerSave) {
         XThreads.executeSynchronized(() -> { // <2>
-            Customer c = data().getCustomers().get(customer.getId());
-            c.setFirstName(customer.getFirstName());
-            c.setLastName(customer.getLastName());
+            Customer c = data().getCustomers().get(id);
+            c.setFirstName(customerSave.getFirstName());
+            c.setLastName(customerSave.getLastName());
             embeddedStorageManager.store(c); // <3>
         });
     }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
@@ -10,6 +10,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
+import java.util.UUID;
 
 @Requires(property = "customer.repository", value = "embedded-storage-manager")
 //tag::clazz[]
@@ -23,37 +24,43 @@ public class CustomerRepositoryImpl implements CustomerRepository {
     }
 
 	@Override
-	public void save(@NonNull @NotNull @Valid Customer customer) {
-        XThreads.executeSynchronized(() -> { // <2>
-            getData().ifPresent(data -> {
-                data.getCustomers().put(customer.getId(), customer);
-                embeddedStorageManager.store(data.getCustomers()); // <3>
-            });
+    @NonNull
+	public Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
+        return XThreads.executeSynchronized(() -> { // <2>
+            String id = UUID.randomUUID().toString();
+            Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
+            data().getCustomers().put(id, customer);
+            embeddedStorageManager.store(data().getCustomers()); // <3>
+            return customer;
         });
 	}
 
     @Override
+    public void update(@NonNull @NotNull @Valid Customer customer) {
+        XThreads.executeSynchronized(() -> { // <2>
+            Customer c = data().getCustomers().get(customer.getId());
+            c.setFirstName(customer.getFirstName());
+            c.setLastName(customer.getLastName());
+            embeddedStorageManager.store(c); // <3>
+        });
+    }
+
+    @Override
     @NonNull
     public Optional<Customer> findById(@NonNull @NotBlank String id) {
-        return getData().flatMap(data -> Optional.ofNullable(data.getCustomers().get(id)));
+        return Optional.ofNullable(data().getCustomers().get(id));
     }
 
     @Override
     public void deleteById(@NonNull @NotBlank String id) {
         XThreads.executeSynchronized(() -> { // <2>
-            getData().ifPresent(data -> {
-                data.getCustomers().remove(id);
-                embeddedStorageManager.store(data.getCustomers()); // <3>
-            });
+            data().getCustomers().remove(id);
+            embeddedStorageManager.store(data().getCustomers()); // <3>
         });
     }
 
-    private Optional<Data> getData() {
-        Object root = embeddedStorageManager.root();
-        if (root instanceof Data) {
-            return Optional.of((Data) root);
-        }
-        return Optional.empty();
+    private Data data() {
+        return (Data) embeddedStorageManager.root();
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
@@ -9,6 +9,7 @@ import one.microstream.storage.embedded.types.EmbeddedStorageManager;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryImpl.java
@@ -4,7 +4,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 import one.microstream.concurrency.XThreads;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -18,10 +18,10 @@ import java.util.UUID;
 @Singleton
 public class CustomerRepositoryImpl implements CustomerRepository {
 
-    private final EmbeddedStorageManager embeddedStorageManager;
+    private final StorageManager storageManager;
 
-    public CustomerRepositoryImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
-        this.embeddedStorageManager = embeddedStorageManager;
+    public CustomerRepositoryImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager;
     }
 
 	@Override
@@ -31,7 +31,7 @@ public class CustomerRepositoryImpl implements CustomerRepository {
             String id = UUID.randomUUID().toString();
             Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
             data().getCustomers().put(id, customer);
-            embeddedStorageManager.store(data().getCustomers()); // <3>
+            storageManager.store(data().getCustomers()); // <3>
             return customer;
         });
 	}
@@ -43,7 +43,7 @@ public class CustomerRepositoryImpl implements CustomerRepository {
             Customer c = data().getCustomers().get(id);
             c.setFirstName(customerSave.getFirstName());
             c.setLastName(customerSave.getLastName());
-            embeddedStorageManager.store(c); // <3>
+            storageManager.store(c); // <3>
         });
     }
 
@@ -57,12 +57,12 @@ public class CustomerRepositoryImpl implements CustomerRepository {
     public void deleteById(@NonNull @NotBlank String id) {
         XThreads.executeSynchronized(() -> { // <2>
             data().getCustomers().remove(id);
-            embeddedStorageManager.store(data().getCustomers()); // <3>
+            storageManager.store(data().getCustomers()); // <3>
         });
     }
 
     private Data data() {
-        return (Data) embeddedStorageManager.root();
+        return (Data) storageManager.root();
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryRootEagerImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryRootEagerImpl.java
@@ -1,0 +1,63 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotation.Store;
+import io.micronaut.microstream.annotation.StoringStrategy;
+import jakarta.inject.Singleton;
+import one.microstream.concurrency.XThreads;
+import one.microstream.storage.types.StorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+import java.util.UUID;
+
+@Requires(property = "customer.repository", value = "root-eager")
+//tag::clazz[]
+@Singleton
+public class CustomerRepositoryRootEagerImpl implements CustomerRepository {
+
+    private final StorageManager storageManager;
+
+    public CustomerRepositoryRootEagerImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager;
+    }
+
+	@Override
+    @NonNull
+    @Store(root = true, strategy = StoringStrategy.EAGER)
+	public Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
+        String id = UUID.randomUUID().toString();
+        Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
+        data().getCustomers().put(id, customer);
+        return customer;
+	}
+
+    @Override
+    @Store(root = true, strategy = StoringStrategy.EAGER)
+    public void update(@NonNull @NotBlank String id,
+                       @NonNull @NotNull @Valid CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id);
+        c.setFirstName(customerSave.getFirstName());
+        c.setLastName(customerSave.getLastName());
+    }
+
+    @Override
+    @NonNull
+    public Optional<Customer> findById(@NonNull @NotBlank String id) {
+        return Optional.ofNullable(data().getCustomers().get(id));
+    }
+
+    @Override
+    @Store(root = true, strategy = StoringStrategy.EAGER)
+    public void deleteById(@NonNull @NotBlank String id) {
+        data().getCustomers().remove(id);
+    }
+
+    private Data data() {
+        return (Data) storageManager.root();
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryRootEagerImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryRootEagerImpl.java
@@ -2,10 +2,9 @@ package io.micronaut.microstream.docs;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.microstream.annotation.Store;
-import io.micronaut.microstream.annotation.StoringStrategy;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoringStrategy;
 import jakarta.inject.Singleton;
-import one.microstream.concurrency.XThreads;
 import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreAnnotationImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreAnnotationImpl.java
@@ -4,9 +4,9 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.microstream.RootProvider;
-import io.micronaut.microstream.annotations.StoreParams;
-import io.micronaut.microstream.annotations.StoreReturn;
+import io.micronaut.microstream.annotations.Store;
 import jakarta.inject.Singleton;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -14,14 +14,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-@Requires(property = "customer.repository", value = "store")
+@Requires(property = "customer.repository", value = "store-annotation")
 //tag::clazz[]
 @Singleton
-public class CustomerRepositoryStoreImpl implements CustomerRepository {
+public class CustomerRepositoryStoreAnnotationImpl implements CustomerRepository {
 
     private final RootProvider<Data> rootProvider;
 
-    public CustomerRepositoryStoreImpl(RootProvider<Data> rootProvider) { // <1>
+    public CustomerRepositoryStoreAnnotationImpl(RootProvider<Data> rootProvider) { // <1>
         this.rootProvider = rootProvider;
     }
 
@@ -48,7 +48,7 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
         removeCustomer(rootProvider.root().getCustomers(), id);
     }
 
-    @StoreReturn // <2>
+    @Store(result = true) // <2>
     @Nullable
     protected Customer updateCustomer(@NonNull String id,
                                       @NonNull CustomerSave customerSave) {
@@ -61,7 +61,7 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
         return null;
     }
 
-    @StoreParams("customers") // <3>
+    @Store(parameters = "customers") // <3>
     protected Customer addCustomer(@NonNull Map<String, Customer> customers,
                                    @NonNull CustomerSave customerSave) {
         Customer customer = new Customer(UUID.randomUUID().toString(),
@@ -71,7 +71,7 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
         return customer;
     }
 
-    @StoreParams("customers") // <3>
+    @Store(parameters = "customers") // <3>
     protected void removeCustomer(@NonNull Map<String, Customer> customers,
                                   @NonNull String id) {
         customers.remove(id);

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
@@ -32,8 +32,9 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
     }
 
     @Override
-    public void update(@NonNull @NotNull @Valid Customer customer) {
-        updateCustomer(customer);
+    public void update(@NonNull @NotBlank String id,
+                       @NonNull @NotNull @Valid CustomerSave customerSave) {
+        updateCustomer(id, customerSave);
     }
 
     @Override
@@ -49,11 +50,12 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
 
     @Store(result = true) // <2>
     @Nullable
-    protected Customer updateCustomer(@NonNull Customer customer) {
-        Customer c = data().getCustomers().get(customer.getId());
+    protected Customer updateCustomer(@NonNull String id,
+                                      @NonNull CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id);
         if (c != null) {
-            c.setFirstName(customer.getFirstName());
-            c.setLastName(customer.getLastName());
+            c.setFirstName(customerSave.getFirstName());
+            c.setLastName(customerSave.getLastName());
             return c;
         }
         return null;

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
@@ -3,10 +3,9 @@ package io.micronaut.microstream.docs;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.microstream.RootProvider;
 import io.micronaut.microstream.annotation.Store;
 import jakarta.inject.Singleton;
-import one.microstream.storage.types.StorageManager;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,16 +18,16 @@ import java.util.UUID;
 @Singleton
 public class CustomerRepositoryStoreImpl implements CustomerRepository {
 
-    private final StorageManager storageManager;
+    private final RootProvider<Data> rootProvider;
 
-    public CustomerRepositoryStoreImpl(StorageManager storageManager) { // <1>
-        this.storageManager = storageManager;
+    public CustomerRepositoryStoreImpl(RootProvider<Data> rootProvider) { // <1>
+        this.rootProvider = rootProvider;
     }
 
     @Override
     @NonNull
     public Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
-        return addCustomer(data().getCustomers(), customerSave);
+        return addCustomer(rootProvider.root().getCustomers(), customerSave);
     }
 
     @Override
@@ -40,19 +39,19 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
     @Override
     @NonNull
     public Optional<Customer> findById(@NonNull @NotBlank String id) {
-        return Optional.ofNullable(data().getCustomers().get(id));
+        return Optional.ofNullable(rootProvider.root().getCustomers().get(id));
     }
 
     @Override
     public void deleteById(@NonNull @NotBlank String id) {
-        removeCustomer(data().getCustomers(), id);
+        removeCustomer(rootProvider.root().getCustomers(), id);
     }
 
     @Store(result = true) // <2>
     @Nullable
     protected Customer updateCustomer(@NonNull String id,
                                       @NonNull CustomerSave customerSave) {
-        Customer c = data().getCustomers().get(id);
+        Customer c = rootProvider.root().getCustomers().get(id);
         if (c != null) {
             c.setFirstName(customerSave.getFirstName());
             c.setLastName(customerSave.getLastName());
@@ -75,11 +74,6 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
     protected void removeCustomer(@NonNull Map<String, Customer> customers,
                                   @NonNull String id) {
         customers.remove(id);
-    }
-
-    @NonNull
-    private Data data() {
-        return (Data) storageManager.root();
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
@@ -1,0 +1,66 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotation.Store;
+import jakarta.inject.Singleton;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.Optional;
+
+@Requires(property = "customer.repository", value = "store")
+//tag::clazz[]
+@Singleton
+public class CustomerRepositoryStoreImpl implements CustomerRepository {
+
+    private final EmbeddedStorageManager embeddedStorageManager;
+
+    public CustomerRepositoryStoreImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
+        this.embeddedStorageManager = embeddedStorageManager;
+    }
+
+	@Override
+	public void save(@NonNull @NotNull @Valid Customer customer) {
+        getData().ifPresent(data -> {
+            addCustomer(data.getCustomers(), customer);
+        });
+	}
+
+	@Store(parameters = "customers") // <2>
+	protected void addCustomer(@NonNull Map<String, Customer> customers,
+                               @NonNull Customer customer) {
+        customers.put(customer.getId(), customer);
+    }
+
+    @Override
+    @NonNull
+    public Optional<Customer> findById(@NonNull @NotBlank String id) {
+        return getData().flatMap(data -> Optional.ofNullable(data.getCustomers().get(id)));
+    }
+
+    @Override
+    public void deleteById(@NonNull @NotBlank String id) {
+      getData().ifPresent(data -> {
+          removeCustomer(data.getCustomers(), id);
+        });
+    }
+
+    @Store(parameters = "customers") // <2>
+    protected void removeCustomer(@NonNull Map<String, Customer> customers,
+                                  @NonNull String id) {
+        customers.remove(id);
+    }
+
+    private Optional<Data> getData() {
+        Object root = embeddedStorageManager.root();
+        if (root instanceof Data) {
+            return Optional.of((Data) root);
+        }
+        return Optional.empty();
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreImpl.java
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.microstream.annotation.Store;
 import jakarta.inject.Singleton;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -19,10 +19,10 @@ import java.util.UUID;
 @Singleton
 public class CustomerRepositoryStoreImpl implements CustomerRepository {
 
-    private final EmbeddedStorageManager embeddedStorageManager;
+    private final StorageManager storageManager;
 
-    public CustomerRepositoryStoreImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
-        this.embeddedStorageManager = embeddedStorageManager;
+    public CustomerRepositoryStoreImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager;
     }
 
     @Override
@@ -79,7 +79,7 @@ public class CustomerRepositoryStoreImpl implements CustomerRepository {
 
     @NonNull
     private Data data() {
-        return (Data) embeddedStorageManager.root();
+        return (Data) storageManager.root();
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreRootEagerImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreRootEagerImpl.java
@@ -1,0 +1,63 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotations.Store;
+import io.micronaut.microstream.annotations.StoreRoot;
+import io.micronaut.microstream.annotations.StoringStrategy;
+import jakarta.inject.Singleton;
+import one.microstream.storage.types.StorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+import java.util.UUID;
+
+@Requires(property = "customer.repository", value = "store-root-eager")
+//tag::clazz[]
+@Singleton
+public class CustomerRepositoryStoreRootEagerImpl implements CustomerRepository {
+
+    private final StorageManager storageManager;
+
+    public CustomerRepositoryStoreRootEagerImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager;
+    }
+
+	@Override
+    @NonNull
+    @StoreRoot(strategy = StoringStrategy.EAGER)
+	public Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
+        String id = UUID.randomUUID().toString();
+        Customer customer = new Customer(id, customerSave.getFirstName(), customerSave.getLastName());
+        data().getCustomers().put(id, customer);
+        return customer;
+	}
+
+    @Override
+    @StoreRoot(strategy = StoringStrategy.EAGER)
+    public void update(@NonNull @NotBlank String id,
+                       @NonNull @NotNull @Valid CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id);
+        c.setFirstName(customerSave.getFirstName());
+        c.setLastName(customerSave.getLastName());
+    }
+
+    @Override
+    @NonNull
+    public Optional<Customer> findById(@NonNull @NotBlank String id) {
+        return Optional.ofNullable(data().getCustomers().get(id));
+    }
+
+    @Override
+    @Store(root = true, strategy = StoringStrategy.EAGER)
+    public void deleteById(@NonNull @NotBlank String id) {
+        data().getCustomers().remove(id);
+    }
+
+    private Data data() {
+        return (Data) storageManager.root();
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.microstream.annotation.Store;
 import jakarta.inject.Singleton;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -19,10 +19,10 @@ import java.util.UUID;
 @Singleton
 public class CustomerRepositoryStoreWithNameQualifierImpl implements CustomerRepository {
 
-    private final EmbeddedStorageManager embeddedStorageManager;
+    private final StorageManager storageManager;
 
-    public CustomerRepositoryStoreWithNameQualifierImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
-        this.embeddedStorageManager = embeddedStorageManager;
+    public CustomerRepositoryStoreWithNameQualifierImpl(StorageManager storageManager) { // <1>
+        this.storageManager = storageManager;
     }
 
     @Override
@@ -79,7 +79,7 @@ public class CustomerRepositoryStoreWithNameQualifierImpl implements CustomerRep
 
     @NonNull
     private Data data() {
-        return (Data) embeddedStorageManager.root();
+        return (Data) storageManager.root();
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
@@ -1,0 +1,85 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.microstream.annotation.Store;
+import jakarta.inject.Singleton;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Requires(property = "customer.repository", value = "store-with-name")
+//tag::clazz[]
+@Singleton
+public class CustomerRepositoryStoreWithNameQualifierImpl implements CustomerRepository {
+
+    private final EmbeddedStorageManager embeddedStorageManager;
+
+    public CustomerRepositoryStoreWithNameQualifierImpl(EmbeddedStorageManager embeddedStorageManager) { // <1>
+        this.embeddedStorageManager = embeddedStorageManager;
+    }
+
+    @Override
+    @NonNull
+    public Customer save(@NonNull @NotNull @Valid CustomerSave customerSave) {
+        return addCustomer(data().getCustomers(), customerSave);
+    }
+
+    @Override
+    public void update(@NonNull @NotBlank String id,
+                       @NonNull @NotNull @Valid CustomerSave customerSave) {
+        updateCustomer(id, customerSave);
+    }
+
+    @Override
+    @NonNull
+    public Optional<Customer> findById(@NonNull @NotBlank String id) {
+        return Optional.ofNullable(data().getCustomers().get(id));
+    }
+
+    @Override
+    public void deleteById(@NonNull @NotBlank String id) {
+        removeCustomer(data().getCustomers(), id);
+    }
+
+    @Store(result = true, name = "main") // <2>
+    @Nullable
+    protected Customer updateCustomer(@NonNull String id,
+                                      @NonNull CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id);
+        if (c != null) {
+            c.setFirstName(customerSave.getFirstName());
+            c.setLastName(customerSave.getLastName());
+            return c;
+        }
+        return null;
+    }
+
+    @Store(parameters = "customers", name = "main") // <3>
+    protected Customer addCustomer(@NonNull Map<String, Customer> customers,
+                                   @NonNull CustomerSave customerSave) {
+        Customer customer = new Customer(UUID.randomUUID().toString(),
+            customerSave.getFirstName(),
+            customerSave.getLastName());
+        customers.put(customer.getId(), customer);
+        return customer;
+    }
+
+    @Store(parameters = "customers", name = "main") // <3>
+    protected void removeCustomer(@NonNull Map<String, Customer> customers,
+                                  @NonNull String id) {
+        customers.remove(id);
+    }
+
+    @NonNull
+    private Data data() {
+        return (Data) embeddedStorageManager.root();
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerRepositoryStoreWithNameQualifierImpl.java
@@ -3,7 +3,7 @@ package io.micronaut.microstream.docs;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.microstream.annotation.Store;
+import io.micronaut.microstream.annotations.Store;
 import jakarta.inject.Singleton;
 import one.microstream.storage.types.StorageManager;
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Customers.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Customers.java
@@ -1,0 +1,17 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Introspected
+public class Customers {
+    @NonNull
+    private Map<String, Customer> customersById = new ConcurrentHashMap<>();
+
+    @NonNull
+    public Map<String, Customer> getCustomersById() {
+        return customersById;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
@@ -17,10 +17,9 @@ class EagerTest {
     void testEagerStrategyWithReturn() {
         String storageDirectory = "build/microstream-" + UUID.randomUUID();
         Map<String, Object> properties = CollectionUtils.mapOf(
-            "microstream.storage.main.storage-directory",
-            storageDirectory,
-            "microstream.storage.main.root-class",
-            "io.micronaut.microstream.docs.CRM");
+            "microstream.storage.main.storage-directory", storageDirectory,
+            "microstream.storage.main.root-class", "io.micronaut.microstream.docs.CRM"
+        );
         ApplicationContext ctx = ApplicationContext.run(properties);
         CRM data = (CRM) ctx.getBean(StorageManager.class).root();
         assertTrue(data.getCustomers().getCustomersById().isEmpty());

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
@@ -3,7 +3,8 @@ package io.micronaut.microstream.docs;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.CollectionUtils;
 import one.microstream.storage.types.StorageManager;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Map;
 import java.util.UUID;
@@ -13,13 +14,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EagerTest {
 
-    @Test
-    void testEagerStrategyWithReturn() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "store",
+        "store-return"
+    })
+    void testEagerStrategyWithReturn(String serviceImplementation) {
         String storageDirectory = "build/microstream-" + UUID.randomUUID();
         Map<String, Object> properties = CollectionUtils.mapOf(
             "microstream.storage.main.storage-directory", storageDirectory,
-            "microstream.storage.main.root-class", "io.micronaut.microstream.docs.CRM"
-        );
+            "microstream.storage.main.root-class", "io.micronaut.microstream.docs.CRM",
+            "spec.service", serviceImplementation);
         ApplicationContext ctx = ApplicationContext.run(properties);
         CRM data = (CRM) ctx.getBean(StorageManager.class).root();
         assertTrue(data.getCustomers().getCustomersById().isEmpty());

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/EagerTest.java
@@ -1,0 +1,34 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.CollectionUtils;
+import one.microstream.storage.types.StorageManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EagerTest {
+
+    @Test
+    void testEagerStrategyWithReturn() {
+        String storageDirectory = "build/microstream-" + UUID.randomUUID();
+        Map<String, Object> properties = CollectionUtils.mapOf(
+            "microstream.storage.main.storage-directory",
+            storageDirectory,
+            "microstream.storage.main.root-class",
+            "io.micronaut.microstream.docs.CRM");
+        ApplicationContext ctx = ApplicationContext.run(properties);
+        CRM data = (CRM) ctx.getBean(StorageManager.class).root();
+        assertTrue(data.getCustomers().getCustomersById().isEmpty());
+        ctx.getBean(CrmCustomerService.class).save(new Customer(UUID.randomUUID().toString(), "Sergio", "del Amo"));
+        ctx.close();
+        ctx = ApplicationContext.run(properties);
+        data = (CRM) ctx.getBean(StorageManager.class).root();
+        assertFalse(data.getCustomers().getCustomersById().isEmpty());
+        ctx.close();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
@@ -1,6 +1,6 @@
 package io.micronaut.microstream.docs;
 
-import io.micronaut.microstream.annotation.Store;
+import io.micronaut.microstream.annotations.Store;
 import jakarta.inject.Singleton;
 import one.microstream.storage.types.StorageManager;
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
@@ -2,16 +2,16 @@ package io.micronaut.microstream.docs;
 
 import io.micronaut.microstream.annotation.Store;
 import jakarta.inject.Singleton;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 import java.util.Map;
 
 @Singleton
 public class StoreNullResult {
-    private final EmbeddedStorageManager embeddedStorageManager;
+    private final StorageManager storageManager;
 
-    public StoreNullResult(EmbeddedStorageManager embeddedStorageManager) {
-        this.embeddedStorageManager = embeddedStorageManager;
+    public StoreNullResult(StorageManager storageManager) {
+        this.storageManager = storageManager;
     }
 
     public void saveNullResult(Customer customer) {
@@ -36,6 +36,6 @@ public class StoreNullResult {
 
 
     Data data() {
-        return (Data) embeddedStorageManager.root();
+        return (Data) storageManager.root();
     }
 }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResult.java
@@ -1,0 +1,41 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.microstream.annotation.Store;
+import jakarta.inject.Singleton;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+
+import java.util.Map;
+
+@Singleton
+public class StoreNullResult {
+    private final EmbeddedStorageManager embeddedStorageManager;
+
+    public StoreNullResult(EmbeddedStorageManager embeddedStorageManager) {
+        this.embeddedStorageManager = embeddedStorageManager;
+    }
+
+    public void saveNullResult(Customer customer) {
+        saveNullResult(data().getCustomers(), customer);
+    }
+
+    @Store(result = true, parameters = {"customers"})
+    Map<String, Customer> saveNullResult(Map<String, Customer> customers, Customer customer) {
+        customers.put(customer.getId(), customer);
+        return null;
+    }
+
+    public void saveNullParams(Customer customer) {
+        saveNullParams(data().getCustomers(), customer, null);
+    }
+
+    @Store(result = true, parameters = {"secondParams"})
+    Map<String, Customer> saveNullParams(Map<String, Customer> customers, Customer customer, Map<String, Object> secondParams) {
+        customers.put(customer.getId(), customer);
+        return customers;
+    }
+
+
+    Data data() {
+        return (Data) embeddedStorageManager.root();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResultTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResultTest.java
@@ -1,0 +1,72 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.CollectionUtils;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StoreNullResultTest {
+
+    @Test
+    void testParamsCanBeNull() {
+        String storageDirectory = "build/microstream-" + UUID.randomUUID();
+        Map<String, Object> properties = CollectionUtils.mapOf(
+            "microstream.storage.main.storage-directory",
+            storageDirectory,
+            "microstream.storage.main.root-class",
+            "io.micronaut.microstream.docs.Data");
+        ApplicationContext ctx = ApplicationContext.run(properties);
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(data.getCustomers().isEmpty());
+
+        StoreNullResult storeNullResult = ctx.getBean(StoreNullResult.class);
+
+        storeNullResult.saveNullParams(new Customer(UUID.randomUUID().toString(), "Sergio", "del Amo"));
+
+        ctx.close();
+
+        ctx = ApplicationContext.run(properties);
+
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertFalse(data.getCustomers().isEmpty());
+
+        ctx.close();
+    }
+
+    @Test
+    void testResultCanBeNull() {
+        String storageDirectory = "build/microstream-" + UUID.randomUUID();
+        Map<String, Object> properties = CollectionUtils.mapOf(
+            "microstream.storage.main.storage-directory",
+            storageDirectory,
+            "microstream.storage.main.root-class",
+            "io.micronaut.microstream.docs.Data");
+        ApplicationContext ctx = ApplicationContext.run(properties);
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(data.getCustomers().isEmpty());
+
+        StoreNullResult storeNullResult = ctx.getBean(StoreNullResult.class);
+
+        storeNullResult.saveNullResult(new Customer(UUID.randomUUID().toString(), "Sergio", "del Amo"));
+
+        ctx.close();
+
+        ctx = ApplicationContext.run(properties);
+
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertFalse(data.getCustomers().isEmpty());
+
+        ctx.close();
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResultTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreNullResultTest.java
@@ -2,7 +2,7 @@ package io.micronaut.microstream.docs;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.CollectionUtils;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -22,8 +22,8 @@ class StoreNullResultTest {
             "microstream.storage.main.root-class",
             "io.micronaut.microstream.docs.Data");
         ApplicationContext ctx = ApplicationContext.run(properties);
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(StorageManager.class).root();
         assertTrue(data.getCustomers().isEmpty());
 
         StoreNullResult storeNullResult = ctx.getBean(StoreNullResult.class);
@@ -34,8 +34,8 @@ class StoreNullResultTest {
 
         ctx = ApplicationContext.run(properties);
 
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(StorageManager.class).root();
         assertFalse(data.getCustomers().isEmpty());
 
         ctx.close();
@@ -50,8 +50,8 @@ class StoreNullResultTest {
             "microstream.storage.main.root-class",
             "io.micronaut.microstream.docs.Data");
         ApplicationContext ctx = ApplicationContext.run(properties);
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(StorageManager.class).root();
         assertTrue(data.getCustomers().isEmpty());
 
         StoreNullResult storeNullResult = ctx.getBean(StoreNullResult.class);
@@ -62,8 +62,8 @@ class StoreNullResultTest {
 
         ctx = ApplicationContext.run(properties);
 
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(StorageManager.class).root();
         assertFalse(data.getCustomers().isEmpty());
 
         ctx.close();

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.microstream.annotation.Store;
 import jakarta.inject.Singleton;
 import one.microstream.concurrency.XThreads;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -13,16 +13,16 @@ import java.util.Optional;
 
 @Singleton
 public class StoreReturnOptional {
-    private final EmbeddedStorageManager embeddedStorageManager;
+    private final StorageManager storageManager;
 
-    public StoreReturnOptional(EmbeddedStorageManager embeddedStorageManager) {
-        this.embeddedStorageManager = embeddedStorageManager;
+    public StoreReturnOptional(StorageManager storageManager) {
+        this.storageManager = storageManager;
     }
 
     public void save(@NonNull @NotNull @Valid Customer customer) {
         XThreads.executeSynchronized(() -> {
             data().getCustomers().put(customer.getId(), customer);
-            embeddedStorageManager.store(data().getCustomers());
+            storageManager.store(data().getCustomers());
         });
     }
 
@@ -40,6 +40,6 @@ public class StoreReturnOptional {
     }
 
     Data data() {
-        return (Data) embeddedStorageManager.root();
+        return (Data) storageManager.root();
     }
 }

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
@@ -2,7 +2,7 @@ package io.micronaut.microstream.docs;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.microstream.annotation.Store;
+import io.micronaut.microstream.annotations.Store;
 import jakarta.inject.Singleton;
 import one.microstream.concurrency.XThreads;
 import one.microstream.storage.types.StorageManager;

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptional.java
@@ -1,0 +1,45 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.microstream.annotation.Store;
+import jakarta.inject.Singleton;
+import one.microstream.concurrency.XThreads;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+@Singleton
+public class StoreReturnOptional {
+    private final EmbeddedStorageManager embeddedStorageManager;
+
+    public StoreReturnOptional(EmbeddedStorageManager embeddedStorageManager) {
+        this.embeddedStorageManager = embeddedStorageManager;
+    }
+
+    public void save(@NonNull @NotNull @Valid Customer customer) {
+        XThreads.executeSynchronized(() -> {
+            data().getCustomers().put(customer.getId(), customer);
+            embeddedStorageManager.store(data().getCustomers());
+        });
+    }
+
+    @Store(result = true)
+    @Nullable
+    protected Optional<Customer> updateCustomer(@NonNull String id,
+                                                @NonNull CustomerSave customerSave) {
+        Customer c = data().getCustomers().get(id);
+        if (c != null) {
+            c.setFirstName(customerSave.getFirstName());
+            c.setLastName(customerSave.getLastName());
+            return Optional.of(c);
+        }
+        return Optional.empty();
+    }
+
+    Data data() {
+        return (Data) embeddedStorageManager.root();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptionalTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptionalTest.java
@@ -1,0 +1,70 @@
+package io.micronaut.microstream.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.CollectionUtils;
+import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StoreReturnOptionalTest {
+
+    @Test
+    void testResultCanBeOptional() {
+        String storageDirectory = "build/microstream-" + UUID.randomUUID();
+        Map<String, Object> properties = CollectionUtils.mapOf(
+            "microstream.storage.main.storage-directory", storageDirectory,
+            "microstream.storage.main.root-class", "io.micronaut.microstream.docs.Data");
+        ApplicationContext ctx = ApplicationContext.run(properties);
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+
+        // When you start there is no data
+        assertTrue(data.getCustomers().isEmpty());
+
+        // Saving one customer
+        String firstName = "Sergio";
+        String lastName = "del Amo";
+        String id = UUID.randomUUID().toString();
+        Customer customer = new Customer(id, firstName, null);
+        ctx.getBean(StoreReturnOptional.class).save(customer);
+
+        ctx.close();
+
+        ctx = ApplicationContext.run(properties);
+
+        // The customer is there after stopping and starting
+        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertFalse(data.getCustomers().isEmpty());
+        Optional<Customer> savedCustomerOptional = data.getCustomers().values().stream().findFirst();
+        assertTrue(savedCustomerOptional.isPresent());
+
+        Customer savedCustomer = savedCustomerOptional.get();
+        assertEquals(id, savedCustomer.getId());
+        assertEquals(firstName, savedCustomer.getFirstName());
+        assertNull(savedCustomer.getLastName());
+
+        // Update the customer in a method which returns an optional wrapping the updated customer
+        ctx.getBean(StoreReturnOptional.class).updateCustomer(id, new CustomerSave(firstName, lastName));
+
+        ctx.close();
+
+        ctx = ApplicationContext.run(properties);
+
+        // The Updated customer was saved
+        savedCustomerOptional = data.getCustomers().values().stream().findFirst();
+        assertTrue(savedCustomerOptional.isPresent());
+
+        savedCustomer = savedCustomerOptional.get();
+        assertEquals(id, savedCustomer.getId());
+        assertEquals(firstName, savedCustomer.getFirstName());
+        assertEquals(lastName, savedCustomer.getLastName());
+
+        ctx.close();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptionalTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/StoreReturnOptionalTest.java
@@ -2,7 +2,7 @@ package io.micronaut.microstream.docs;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.CollectionUtils;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -20,8 +20,8 @@ class StoreReturnOptionalTest {
             "microstream.storage.main.storage-directory", storageDirectory,
             "microstream.storage.main.root-class", "io.micronaut.microstream.docs.Data");
         ApplicationContext ctx = ApplicationContext.run(properties);
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        Data data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        Data data = (Data) ctx.getBean(StorageManager.class).root();
 
         // When you start there is no data
         assertTrue(data.getCustomers().isEmpty());
@@ -38,8 +38,8 @@ class StoreReturnOptionalTest {
         ctx = ApplicationContext.run(properties);
 
         // The customer is there after stopping and starting
-        assertTrue(ctx.getBean(EmbeddedStorageManager.class).root() instanceof Data);
-        data = (Data) ctx.getBean(EmbeddedStorageManager.class).root();
+        assertTrue(ctx.getBean(StorageManager.class).root() instanceof Data);
+        data = (Data) ctx.getBean(StorageManager.class).root();
         assertFalse(data.getCustomers().isEmpty());
         Optional<Customer> savedCustomerOptional = data.getCustomers().values().stream().findFirst();
         assertTrue(savedCustomerOptional.isPresent());


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-microstream/pull/19

and: https://github.com/micronaut-projects/micronaut-microstream/issues/16

I have added several annotations: 

`@StoreReturn`, `@StoreParam`. and `@StoreRoot` they map to `@Store`. That it is, we have a single interceptor but four annotations. Typically users will never work with `@Store` directly. But it is the annotation every other annotation is mapped to. 

I have replaced `EmbeddedStorageManager` with `StorageManager`. 

This provides a a bean of type `RootProvider<T>` for easy retrieval of a typed Root instance. 

I have added the concept of storing stragey. You can for example annotate a method with `@StoreRoot(startegy=StoringStrategy.EAGER)` and it will cascade the storage and the root objects and descendants. 

I added a Patch endpoint. 
