### PR TITLE
build: Switch to use the micronaut catalog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.microstream
 micronautDocsVersion=2.0.0
-micronautVersion=3.4.3
+micronautVersion=3.4.4
 micronautTestVersion=3.1.1
 groovyVersion=3.0.10
 spockVersion=2.1-groovy-3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,19 +14,7 @@ jupiter-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params' }
 jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
 
-micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
-micronaut-test-junit5 = { module = 'io.micronaut.test:micronaut-test-junit5' }
 micronaut-cache-core = { module = 'io.micronaut.cache:micronaut-cache-core', version = "3.4.1" }
-micronaut-cache-tck = { module = 'io.micronaut.cache:micronaut-cache-tck'}
-micronaut-aop = { module = "io.micronaut:micronaut-aop" }
-micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
-micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
-micronaut-jackson-databind = { module = "io.micronaut:micronaut-jackson-databind" }
-micronaut-management = { module = "io.micronaut:micronaut-management" }
-micronaut-micrometer-core = { module = 'io.micronaut.micrometer:micronaut-micrometer-core' }
-micronaut-validation = { module = 'io.micronaut:micronaut-validation' }
-micronaut-inject-groovy = { module = 'io.micronaut:micronaut-inject-groovy' }
-micronaut-test-spock = { module = 'io.micronaut.test:micronaut-test-spock' }
 
 projectreactor = { module = 'io.projectreactor:reactor-core' }
 projectreactor-test = { module = "io.projectreactor:reactor-test", version.ref = 'reactor-test' }

--- a/microstream-annotations/build.gradle.kts
+++ b/microstream-annotations/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.micronaut.aop)
+    implementation(mn.micronaut.aop)
 }
 
 micronautBuild {

--- a/microstream-cache/build.gradle.kts
+++ b/microstream-cache/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     api(project(":microstream"))
     api(libs.managed.microstream.cache)
     api(libs.micronaut.cache.core)
-    testImplementation(libs.micronaut.cache.tck)
+    testImplementation(mn.micronaut.cache.tck)
     testImplementation(libs.jupiter.api)
 }
 

--- a/microstream-rest/build.gradle.kts
+++ b/microstream-rest/build.gradle.kts
@@ -3,16 +3,16 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor(libs.micronaut.validation)
+    annotationProcessor(mn.micronaut.validation)
 
     implementation(libs.managed.microstream.storage.restservice)
-    implementation(libs.micronaut.validation)
+    implementation(mn.micronaut.validation)
 
     implementation(project(":microstream"))
-    implementation(libs.micronaut.jackson.databind)
+    implementation(mn.micronaut.jackson.databind)
 
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
 }
 
 micronautBuild {

--- a/microstream/build.gradle.kts
+++ b/microstream/build.gradle.kts
@@ -3,18 +3,18 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.micronaut.micrometer.core)
+    compileOnly(mn.micronaut.micrometer.core)
     compileOnly(project(":microstream-annotations"))
     api(libs.managed.microstream.storage.embedded.configuration)
 
-    compileOnly(libs.micronaut.management)
+    compileOnly(mn.micronaut.management)
     implementation(libs.projectreactor)
 
     testImplementation(libs.projectreactor.test)
-    testImplementation(libs.micronaut.micrometer.core)
-    testImplementation(libs.micronaut.management)
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.http.client)
+    testImplementation(mn.micronaut.micrometer.core)
+    testImplementation(mn.micronaut.management)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
     testImplementation(project(":microstream-annotations"))
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,7 @@ include 'microstream-cache'
 include 'test-suite'
 include 'test-suite-groovy'
 include 'test-suite-kotlin'
+
+micronautBuild {
+    importMicronautCatalog()
+}

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -7,16 +7,16 @@ repositories {
 dependencies {
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
 
-    testCompileOnly(libs.micronaut.inject.groovy)
+    testCompileOnly(mn.micronaut.inject.groovy)
 
     testImplementation(project(":microstream-annotations"))
-    testImplementation(libs.micronaut.validation)
+    testImplementation(mn.micronaut.validation)
     testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude module: 'groovy-all'
     }
-    testImplementation(libs.micronaut.test.spock)
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.http.client)
+    testImplementation(mn.micronaut.test.spock)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
     testImplementation(project(":microstream"))
     testImplementation project(":microstream-cache")
 

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -13,17 +13,17 @@ dependencies {
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testImplementation(project(":microstream-annotations"))
 
-    testImplementation(libs.micronaut.validation)
+    testImplementation(mn.micronaut.validation)
 
     testImplementation(libs.jupiter.api)
-    testImplementation(libs.micronaut.test.junit5)
+    testImplementation(mn.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.logback.classic)
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21"
-    kaptTest(libs.micronaut.inject.java)
+    kaptTest(mn.micronaut.inject.java)
 
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
     testImplementation project(":microstream")
     testImplementation(libs.jupiter.jupiter.params)
     testImplementation project(":microstream-cache")

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -7,21 +7,21 @@ repositories {
 dependencies {
     testAnnotationProcessor(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testAnnotationProcessor(project(":microstream-annotations"))
-    testAnnotationProcessor(libs.micronaut.inject.java)
-    testAnnotationProcessor(libs.micronaut.validation)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(mn.micronaut.validation)
 
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
-    testImplementation(libs.micronaut.validation)
+    testImplementation(mn.micronaut.validation)
 
     testImplementation(project(":microstream-annotations"))
 
     testImplementation(libs.jupiter.api)
-    testImplementation(libs.micronaut.test.junit5)
+    testImplementation(mn.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)
 
     testRuntimeOnly(libs.logback.classic)
-    testImplementation(libs.micronaut.http.server.netty)
-    testImplementation(libs.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
     testImplementation project(":microstream")
     testImplementation project(":microstream-cache")
     testImplementation project(":microstream-rest")


### PR DESCRIPTION
We need to use a specific cache version as that isn't out until Micronaut 3.5.0