### PR TITLE
Disable rest by default

### DIFF
--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/Store.java
@@ -97,7 +97,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }
  * </pre>
  *
- * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">MicroStream mutable data docs.</a>
  * @since 1.0.0
  * @author Tim Yates
  * @author Sergio del Amo
@@ -109,7 +109,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Store {
     /**
      * The optional name qualifier of the StorageManager to use.
-     * If your application only have a Microstream instance, this is not required
+     * If your application only have a MicroStream instance, this is not required
      *
      * @return The name qualifier of the StorageManager to use.
      */

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreParams.java
@@ -60,7 +60,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }
  * </pre>
  *
- * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">MicroStream mutable data docs.</a>
  * @since 1.0.0
  * @author Tim Yates
  * @author Sergio del Amo
@@ -71,7 +71,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface StoreParams {
     /**
      * The optional name qualifier of the Store Manager to use.
-     * If your application only have a Microstream instance, this is not required
+     * If your application only have a MicroStream instance, this is not required
      *
      * @return The name qualifier of the Store Manager to use.
      */

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreReturn.java
@@ -68,7 +68,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }
  * </pre>
  *
- * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">MicroStream mutable data docs.</a>
  * @since 1.0.0
  * @author Sergio del Amo
  */
@@ -78,7 +78,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface StoreReturn {
     /**
      * The optional name qualifier of the Storage Manager to use.
-     * If your application only have a Microstream instance, this is not required
+     * If your application only have a MicroStream instance, this is not required
      *
      * @return The name qualifier of the Storage Manager to use.
      */

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRoot.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/StoreRoot.java
@@ -26,9 +26,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  *
- * An around annotation for methods which saves the Root Object of a Microstream instance.
+ * An around annotation for methods which saves the Root Object of a MicroStream instance.
  *
- * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">Microstream mutable data docs.</a>
+ * @see <a href="https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data">MicroStream mutable data docs.</a>
  * @since 1.0.0
  * @author Sergio del Amo
  */
@@ -38,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface StoreRoot {
     /**
      * The optional name qualifier of the StorageManager to use.
-     * If your application only have a Microstream instance, this is not required
+     * If your application only have a MicroStream instance, this is not required
      *
      * @return The name qualifier of the StorageManager to use.
      */

--- a/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/package-info.java
+++ b/microstream-annotations/src/main/java/io/micronaut/microstream/annotations/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Packages relates to Microstream annotations.
+ * Packages relates to MicroStream annotations.
  * @author Sergio del Amo
  * @since 1.0.0
  */

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/CacheConfiguration.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/CacheConfiguration.java
@@ -19,7 +19,7 @@ import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.core.util.Toggleable;
 
 /**
- * Global Microstream Cache configuration.
+ * Global MicroStream Cache configuration.
  * {@link CacheConfiguration} and {@link CacheConfigurationProperties} exist to generate configuration reference documentation automatically.
  * we generate documentation reference.
  * @author Sergio del Amo

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/CacheConfigurationProperties.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/CacheConfigurationProperties.java
@@ -18,7 +18,7 @@ package io.micronaut.microstream.cache;
 import io.micronaut.context.annotation.ConfigurationProperties;
 
 /**
- * Configuration for Microstream Cache module.
+ * Configuration for MicroStream Cache module.
  * {@link CacheConfiguration} and {@link CacheConfigurationProperties} exist to generate configuration reference documentation automatically.
  * @author Sergio del Amo
  * @since 1.0.0
@@ -27,7 +27,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 @ConfigurationProperties(MicroStreamCacheConfigurationProperties.PREFIX)
 public class CacheConfigurationProperties implements CacheConfiguration {
     /**
-     * Whether Microstream Cache module is enabled.
+     * Whether MicroStream Cache module is enabled.
      */
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ENABLED = true;
@@ -40,7 +40,7 @@ public class CacheConfigurationProperties implements CacheConfiguration {
     }
 
     /**
-     * Whether Microstream Cache module is enabled. Default Value: {@value CacheConfigurationProperties#DEFAULT_ENABLED}
+     * Whether MicroStream Cache module is enabled. Default Value: {@value CacheConfigurationProperties#DEFAULT_ENABLED}
      * @param enabled Whether this cache is enabled.
      */
     public void setEnabled(boolean enabled) {

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/ExpiryPolicyFactory.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/ExpiryPolicyFactory.java
@@ -19,7 +19,7 @@ import javax.cache.configuration.Factory;
 import javax.cache.expiry.ExpiryPolicy;
 
 /**
- * A marker class for defining an expiry policy on Microstream backed caches.
+ * A marker class for defining an expiry policy on MicroStream backed caches.
  *
  * @author Tim Yates
  * @since 1.0.0

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/MicroStreamCacheConfigurationProperties.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/MicroStreamCacheConfigurationProperties.java
@@ -141,7 +141,7 @@ public class MicroStreamCacheConfigurationProperties<K, V> implements MicroStrea
 
     /**
      *
-     * @param storage Name qualifier for Microstream Storage Manager
+     * @param storage Name qualifier for MicroStream Storage Manager
      */
     public void setStorage(@Nullable String storage) {
         this.storage = storage;

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/MicroStreamSyncCache.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/MicroStreamSyncCache.java
@@ -22,7 +22,7 @@ import javax.cache.Cache;
 import java.util.concurrent.ExecutorService;
 
 /**
- * A {@link io.micronaut.cache.SyncCache} implementation that uses a Microstream Cache instance.
+ * A {@link io.micronaut.cache.SyncCache} implementation that uses a MicroStream Cache instance.
  *
  * @param <K> the key type
  * @param <V> the value type

--- a/microstream-cache/src/main/java/io/micronaut/microstream/cache/package-info.java
+++ b/microstream-cache/src/main/java/io/micronaut/microstream/cache/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Microstream classes related to caching.
+ * MicroStream classes related to caching.
  *
  * @see <a href="https://micronaut-projects.github.io/micronaut-cache/latest/guide/">Micronaut Cache</a>
  * @author Tim Yates

--- a/microstream-cache/src/test/groovy/example/micronaut/MicrostreamCacheDisabledSpec.groovy
+++ b/microstream-cache/src/test/groovy/example/micronaut/MicrostreamCacheDisabledSpec.groovy
@@ -5,7 +5,7 @@ import io.micronaut.core.util.StringUtils
 import io.micronaut.microstream.cache.CacheConfiguration
 import spock.lang.Specification
 
-class MicrostreamCacheDisabledSpec extends Specification {
+class MicroStreamCacheDisabledSpec extends Specification {
 
     void "you can disable cache by setting microstream.cache.enabled to false"() {
         given:

--- a/microstream-cache/src/test/groovy/io/micronaut/microstream/cache/MicrostreamAsyncCacheSpec.groovy
+++ b/microstream-cache/src/test/groovy/io/micronaut/microstream/cache/MicrostreamAsyncCacheSpec.groovy
@@ -6,7 +6,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.TempDir
 
-class MicrostreamAsyncCacheSpec extends AbstractAsyncCacheSpec {
+class MicroStreamAsyncCacheSpec extends AbstractAsyncCacheSpec {
 
     @TempDir
     @Shared

--- a/microstream-rest/build.gradle.kts
+++ b/microstream-rest/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(libs.logback.classic)
 }
 
 micronautBuild {

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/DefaultMicroStreamRestService.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/DefaultMicroStreamRestService.java
@@ -29,13 +29,13 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Default implementation of {@link MicrostreamRestService}.
+ * Default implementation of {@link MicroStreamRestService}.
  *
  * @author Tim Yates
  * @since 1.0.0
  */
 @Singleton
-public class DefaultMicroStreamRestService implements MicrostreamRestService {
+public class DefaultMicroStreamRestService implements MicroStreamRestService {
 
     private final Map<String, StorageRestAdapter> adapterMap = new ConcurrentHashMap<>();
     private final String singleStorageName;

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/DefaultMicroStreamRestService.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/DefaultMicroStreamRestService.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 1.0.0
  */
 @Singleton
-public class DefaultMicrostreamRestService implements MicrostreamRestService {
+public class DefaultMicroStreamRestService implements MicrostreamRestService {
 
     private final Map<String, StorageRestAdapter> adapterMap = new ConcurrentHashMap<>();
     private final String singleStorageName;
@@ -46,7 +46,7 @@ public class DefaultMicrostreamRestService implements MicrostreamRestService {
      * @param beanContext the bean context to resolve storage managers
      * @param storageFoundations the bound storage foundations
      */
-    public DefaultMicrostreamRestService(
+    public DefaultMicroStreamRestService(
         BeanContext beanContext,
         Collection<EmbeddedStorageConfigurationProvider> storageFoundations
     ) {

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestController.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestController.java
@@ -29,7 +29,7 @@ import one.microstream.storage.restadapter.types.ViewerStorageFileStatistics;
 import one.microstream.storage.types.StorageManager;
 
 /**
- * Microstream REST controller for a single StorageManager.
+ * MicroStream REST controller for a single StorageManager.
  *
  * @author Tim Yates
  * @since 1.0.0

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestService.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestService.java
@@ -21,7 +21,7 @@ import one.microstream.storage.restadapter.types.StorageRestAdapter;
 import java.util.Optional;
 
 /**
- * Microstream REST service.
+ * MicroStream REST service.
  *
  * @author Tim Yates
  * @since 1.0.0

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestStartupWarning.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicroStreamRestStartupWarning.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.microstream.rest;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@Internal
+@Requires(notEnv = Environment.TEST)
+final class MicroStreamRestStartupWarning implements ApplicationEventListener<StartupEvent> {
+
+    static final String WARNING_MESSAGE = "*****************\n\n" +
+        "\tThe MicroStream REST endpoint is enabled and you are not running in a test environment.\n" +
+        "\tThis endpoint is not intended for production use as it may allow data to be exfiltrated.\n" +
+        "\tPlease see https://micronaut-projects.github.io/micronaut-microstream/snapshot/guide/#rest for instruction on how to disable.";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MicroStreamRestStartupWarning.class);
+
+    @Override
+    public void onApplicationEvent(StartupEvent event) {
+        LOG.warn(WARNING_MESSAGE);
+    }
+}

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicrostreamRestControllerConfigurationProperties.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/MicrostreamRestControllerConfigurationProperties.java
@@ -35,7 +35,7 @@ public class MicrostreamRestControllerConfigurationProperties implements Microst
      * The default enable value.
      */
     @SuppressWarnings("WeakerAccess")
-    public static final boolean DEFAULT_ENABLED = true;
+    public static final boolean DEFAULT_ENABLED = false;
 
     /**
      * The default path.

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/package-info.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/package-info.java
@@ -21,7 +21,7 @@
  * @since 1.0.0
  */
 @Configuration
-@Requires(property = MicrostreamRestControllerConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@Requires(property = MicroStreamRestControllerConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 package io.micronaut.microstream.rest;
 
 import io.micronaut.context.annotation.Configuration;

--- a/microstream-rest/src/main/java/io/micronaut/microstream/rest/package-info.java
+++ b/microstream-rest/src/main/java/io/micronaut/microstream/rest/package-info.java
@@ -21,7 +21,7 @@
  * @since 1.0.0
  */
 @Configuration
-@Requires(property = MicrostreamRestControllerConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = MicrostreamRestControllerConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 package io.micronaut.microstream.rest;
 
 import io.micronaut.context.annotation.Configuration;

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
@@ -17,7 +17,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 @MicronautTest
-@Property(name = "spec.name", value = "MicrostreamRestControllerSpec")
+@Property(name = "spec.name", value = "MicroStreamRestControllerSpec")
 class MicroStreamRestControllerSingleStorageSpec extends Specification implements TestPropertyProvider {
 
     @TempDir

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
@@ -18,7 +18,7 @@ import spock.lang.TempDir
 
 @MicronautTest
 @Property(name = "spec.name", value = "MicrostreamRestControllerSpec")
-class MicrostreamRestControllerSpec extends Specification implements TestPropertyProvider {
+class MicroStreamRestControllerSingleStorageSpec extends Specification implements TestPropertyProvider {
 
     @TempDir
     @Shared
@@ -37,21 +37,12 @@ class MicrostreamRestControllerSpec extends Specification implements TestPropert
                 'microstream.rest.enabled': 'true',
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
-                "microstream.storage.towns.root-class": Towns.class.name,
-                "microstream.storage.towns.storage-directory" : new File(tempDir, "towns").absolutePath,
         ]
     }
 
     void 'file statistics exists'() {
         when:
         def statistics = stats()
-
-        then:
-        statistics.creationTime
-        !statistics.channelStatistics.empty
-
-        when:
-        statistics = stats('towns')
 
         then:
         statistics.creationTime
@@ -117,23 +108,23 @@ class MicrostreamRestControllerSpec extends Specification implements TestPropert
     }
 
     @NonNull
-    private ViewerStorageFileStatistics stats(String manager = 'people') {
-        read("/microstream/$manager/maintenance/filesStatistics", ViewerStorageFileStatistics)
+    private ViewerStorageFileStatistics stats() {
+        read("/microstream/maintenance/filesStatistics", ViewerStorageFileStatistics)
     }
 
     @NonNull
-    private RootObject root(String manager = 'people') {
-        read("/microstream/$manager/root", RootObject)
+    private RootObject root() {
+        read("/microstream/root", RootObject)
     }
 
     @NonNull
     private String dictionary(String manager = 'people') {
-        httpClient.toBlocking().retrieve("/microstream/$manager/dictionary")
+        httpClient.toBlocking().retrieve("/microstream/dictionary")
     }
 
     @NonNull
-    private ViewerObjectDescription object(String id, String manager = 'people') {
-        return read("/microstream/$manager/object/$id", ViewerObjectDescription)
+    private ViewerObjectDescription object(String id) {
+        return read("/microstream/object/$id", ViewerObjectDescription)
     }
 
     @NonNull

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
@@ -18,7 +18,7 @@ import spock.lang.TempDir
 
 @MicronautTest
 @Property(name = "spec.name", value = "MicrostreamRestControllerSpec")
-class MicrostreamRestControllerSingleStorageSpec extends Specification implements TestPropertyProvider {
+class MicroStreamRestControllerSpec extends Specification implements TestPropertyProvider {
 
     @TempDir
     @Shared
@@ -37,12 +37,21 @@ class MicrostreamRestControllerSingleStorageSpec extends Specification implement
                 'microstream.rest.enabled': 'true',
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
+                "microstream.storage.towns.root-class": Towns.class.name,
+                "microstream.storage.towns.storage-directory" : new File(tempDir, "towns").absolutePath,
         ]
     }
 
     void 'file statistics exists'() {
         when:
         def statistics = stats()
+
+        then:
+        statistics.creationTime
+        !statistics.channelStatistics.empty
+
+        when:
+        statistics = stats('towns')
 
         then:
         statistics.creationTime
@@ -108,23 +117,23 @@ class MicrostreamRestControllerSingleStorageSpec extends Specification implement
     }
 
     @NonNull
-    private ViewerStorageFileStatistics stats() {
-        read("/microstream/maintenance/filesStatistics", ViewerStorageFileStatistics)
+    private ViewerStorageFileStatistics stats(String manager = 'people') {
+        read("/microstream/$manager/maintenance/filesStatistics", ViewerStorageFileStatistics)
     }
 
     @NonNull
-    private RootObject root() {
-        read("/microstream/root", RootObject)
+    private RootObject root(String manager = 'people') {
+        read("/microstream/$manager/root", RootObject)
     }
 
     @NonNull
     private String dictionary(String manager = 'people') {
-        httpClient.toBlocking().retrieve("/microstream/dictionary")
+        httpClient.toBlocking().retrieve("/microstream/$manager/dictionary")
     }
 
     @NonNull
-    private ViewerObjectDescription object(String id) {
-        return read("/microstream/object/$id", ViewerObjectDescription)
+    private ViewerObjectDescription object(String id, String manager = 'people') {
+        return read("/microstream/$manager/object/$id", ViewerObjectDescription)
     }
 
     @NonNull

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
@@ -17,7 +17,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 @MicronautTest
-@Property(name = "spec.name", value = "MicrostreamRestControllerSpec")
+@Property(name = "spec.name", value = "MicroStreamRestControllerSpec")
 class MicroStreamRestControllerSpec extends Specification implements TestPropertyProvider {
 
     @TempDir

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestStartupWarningSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestStartupWarningSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.microstream.rest
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.core.annotation.NonNull
+import org.slf4j.LoggerFactory
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class MicroStreamRestStartupWarningSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    @AutoCleanup("stop")
+    ListAppender<ILoggingEvent> listAppender
+
+    void setup() {
+        listAppender = new ListAppender<>()
+        listAppender.start()
+        LoggerFactory.getLogger(MicroStreamRestStartupWarning).addAppender(listAppender)
+    }
+
+    void "logging is shown when enabled"() {
+        given:
+        def server = startServer(
+                "microstream.storage.people.root-class": People.class.name,
+                "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
+                'microstream.rest.enabled': 'true',
+                "not-test"
+        )
+
+        expect:
+        with(listAppender.list[0]) {
+            level == Level.WARN
+            formattedMessage == MicroStreamRestStartupWarning.WARNING_MESSAGE
+        }
+
+        cleanup:
+        server.stop()
+    }
+
+    void "logging is not shown under test"() {
+        given:
+        def server = startServer(
+                "microstream.storage.people.root-class": People.class.name,
+                "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
+                'microstream.rest.enabled': 'true',
+        )
+
+        expect:
+        listAppender.list.empty
+
+        cleanup:
+        server.stop()
+    }
+
+    void "logging is not shown when disabled"() {
+        given:
+        def server = startServer(
+                "microstream.storage.people.root-class": People.class.name,
+                "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
+                'not-test'
+        )
+
+        expect:
+        listAppender.list.empty
+
+        cleanup:
+        server.stop()
+    }
+
+    @NonNull
+    ApplicationContext startServer(Map props = [:], String env = Environment.TEST) {
+        ApplicationContext.builder().deduceEnvironment(false).properties(props).environments(env).build().start()
+    }
+}

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicrostreamRestControllerSingleStorageSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicrostreamRestControllerSingleStorageSpec.groovy
@@ -34,6 +34,7 @@ class MicrostreamRestControllerSingleStorageSpec extends Specification implement
     @Override
     Map<String, String> getProperties() {
         [
+                'microstream.rest.enabled': 'true',
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
         ]

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicrostreamRestControllerSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicrostreamRestControllerSpec.groovy
@@ -34,6 +34,7 @@ class MicrostreamRestControllerSpec extends Specification implements TestPropert
     @Override
     Map<String, String> getProperties() {
         [
+                'microstream.rest.enabled': 'true',
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
                 "microstream.storage.towns.root-class": Towns.class.name,

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/RestConfigurationSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/RestConfigurationSpec.groovy
@@ -26,6 +26,7 @@ class RestConfigurationSpec extends Specification {
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
                 'microstream.rest.path': 'api',
+                'microstream.rest.enabled': 'true',
         )
         def client = getClient(server)
         def mapper = server.applicationContext.getBean(ObjectMapper)
@@ -56,10 +57,9 @@ class RestConfigurationSpec extends Specification {
         server.stop()
     }
 
-    void "controller is disabled if microstream.rest.enabled is set to false"() {
+    void "controller is disabled by default"() {
         given:
         def server = startServer(
-                "microstream.rest.enabled": StringUtils.FALSE,
                 "microstream.storage.people.root-class": People.class.name,
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
         )
@@ -90,6 +90,7 @@ class RestConfigurationSpec extends Specification {
                 "microstream.storage.people.storage-directory": new File(tempDir, "people").absolutePath,
                 "microstream.storage.towns.root-class": Towns.class.name,
                 "microstream.storage.towns.storage-directory": new File(tempDir, "towns").absolutePath,
+                'microstream.rest.enabled': 'true',
         )
         def client = getClient(server)
         def mapper = server.applicationContext.getBean(ObjectMapper)

--- a/microstream/src/main/java/io/micronaut/microstream/RootProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/RootProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.microstream;
 
 /**
- * Functional interface to ease getting the Root Instance of Microstream Store Manager.
+ * Functional interface to ease getting the Root Instance of MicroStream Store Manager.
  * @author Sergio del Amo
  * @since 1.0.0
  * @param <T> The type of the root instance.

--- a/microstream/src/main/java/io/micronaut/microstream/conf/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/package-info.java
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 /**
- * Microstream Configuration files.
- * <a href="https://docs.microstream.one/manual/storage/configuration/index.html">Microstream Configuration</a>
+ * MicroStream Configuration files.
+ * <a href="https://docs.microstream.one/manual/storage/configuration/index.html">MicroStream Configuration</a>
  * @author Sergio del Amo
  * @since 1.0.0
  */

--- a/microstream/src/main/java/io/micronaut/microstream/health/MicroStreamHealth.java
+++ b/microstream/src/main/java/io/micronaut/microstream/health/MicroStreamHealth.java
@@ -18,7 +18,7 @@ package io.micronaut.microstream.health;
 import io.micronaut.core.annotation.Introspected;
 
 /**
- * Health information about a Microstream instance.
+ * Health information about a MicroStream instance.
  * @author Sergio del Amo
  * @since 1.0.0
  */
@@ -34,12 +34,12 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @param startingUp Whether the Microstream instance is starting up.
-     * @param running Whether the Microstream instance is running
-     * @param active Whether the Microstream instance is active
-     * @param acceptingTasks Whether the Microstream instance accepts tasks
-     * @param shuttingDown Whether the Microstream instance is shutting down
-     * @param shutdown Whether the Microstream instance is off
+     * @param startingUp Whether the MicroStream instance is starting up.
+     * @param running Whether the MicroStream instance is running
+     * @param active Whether the MicroStream instance is active
+     * @param acceptingTasks Whether the MicroStream instance accepts tasks
+     * @param shuttingDown Whether the MicroStream instance is shutting down
+     * @param shutdown Whether the MicroStream instance is off
      */
     public MicroStreamHealth(boolean startingUp,
                              boolean running,
@@ -57,7 +57,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance is starting up.
+     * @return Whether the MicroStream instance is starting up.
      */
     public boolean isStartingUp() {
         return startingUp;
@@ -65,7 +65,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance is running
+     * @return Whether the MicroStream instance is running
      */
     public boolean isRunning() {
         return running;
@@ -73,7 +73,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance is active
+     * @return Whether the MicroStream instance is active
      */
     public boolean isActive() {
         return active;
@@ -81,7 +81,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance accepts tasks
+     * @return Whether the MicroStream instance accepts tasks
      */
     public boolean isAcceptingTasks() {
         return acceptingTasks;
@@ -89,7 +89,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance is shutting down
+     * @return Whether the MicroStream instance is shutting down
      */
     public boolean isShuttingDown() {
         return shuttingDown;
@@ -97,7 +97,7 @@ public class MicroStreamHealth {
 
     /**
      *
-     * @return Whether the Microstream instance is off
+     * @return Whether the MicroStream instance is off
      */
     public boolean isShutdown() {
         return shutdown;

--- a/microstream/src/main/java/io/micronaut/microstream/health/MicroStreamHealthIndicator.java
+++ b/microstream/src/main/java/io/micronaut/microstream/health/MicroStreamHealthIndicator.java
@@ -41,14 +41,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Singleton
 @Requires(classes = HealthIndicator.class)
-@Requires(property = HealthEndpoint.PREFIX + "." +  MicrostreamHealthIndicator.MICROSTREAM_PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
-public class MicrostreamHealthIndicator implements HealthIndicator {
+@Requires(property = HealthEndpoint.PREFIX + "." +  MicroStreamHealthIndicator.MICROSTREAM_PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+public class MicroStreamHealthIndicator implements HealthIndicator {
 
     public static final String MICROSTREAM_PREFIX = "microstream";
     private static final String DOT = ".";
     private final Map<String, StorageManager> storageManagerMap = new ConcurrentHashMap<>();
 
-    public MicrostreamHealthIndicator(BeanContext beanContext) {
+    public MicroStreamHealthIndicator(BeanContext beanContext) {
         for (BeanDefinition<StorageManager> definition : beanContext.getBeanDefinitions(StorageManager.class)) {
             if (definition.getDeclaredQualifier() instanceof Named) {
                 String name = ((Named) definition.getDeclaredQualifier()).getName();

--- a/microstream/src/main/java/io/micronaut/microstream/interceptors/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/interceptors/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Class related to interceptors to provide functionality for the Microstream annotations.
+ * Class related to interceptors to provide functionality for the MicroStream annotations.
  * @author Sergio del Amo
  * @since 1.0.0
  */

--- a/microstream/src/main/java/io/micronaut/microstream/metrics/MicroStreamMetricsBinder.java
+++ b/microstream/src/main/java/io/micronaut/microstream/metrics/MicroStreamMetricsBinder.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 import static io.micronaut.microstream.metrics.MicroStreamMetricsBinder.MICROSTREAM_METRIC_PREFIX;
 
 /**
- * A Micronaut {@link MeterBinder} for Microstream integration.
+ * A Micronaut {@link MeterBinder} for MicroStream integration.
  *
  * @since 1.0.0
  * @author Tim Yates

--- a/microstream/src/main/java/io/micronaut/microstream/metrics/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/metrics/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Microstream classes related to Metrics.
+ * MicroStream classes related to Metrics.
  * @see <a href="https://micronaut-projects.github.io/micronaut-micrometer/latest/guide">Micronaut Micrometer</a>
  * @author Sergio del Amo
  * @since 1.0.0

--- a/microstream/src/main/java/io/micronaut/microstream/package-info.java
+++ b/microstream/src/main/java/io/micronaut/microstream/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Class related to Microstream integration with the Micronaut Framework.
+ * Class related to MicroStream integration with the Micronaut Framework.
  * @author Sergio del Amo
  * @since 1.0.0
  */

--- a/microstream/src/test/groovy/io/micronaut/microstream/health/MicroStreamHealthIndicatorFuncSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/health/MicroStreamHealthIndicatorFuncSpec.groovy
@@ -22,7 +22,7 @@ class MicroStreamHealthIndicatorFuncSpec extends Specification {
     @Unroll
     void "#desc manager is #expectedStatus"() {
         when:
-        MicrostreamHealthIndicator healthIndicator = beanContext.getBean(MicrostreamHealthIndicator)
+        MicroStreamHealthIndicator healthIndicator = beanContext.getBean(MicroStreamHealthIndicator)
         StepVerifier.create(healthIndicator.result)
                 .expectNextMatches(t -> t.status == expectedStatus)
                 .verifyComplete()

--- a/microstream/src/test/groovy/io/micronaut/microstream/health/MicroStreamHealthIndicatorSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/health/MicroStreamHealthIndicatorSpec.groovy
@@ -10,7 +10,7 @@ class MicroStreamHealthIndicatorSpec extends Specification {
         ApplicationContext context = ApplicationContext.run(['endpoints.health.microstream.enabled': false])
 
         expect:
-        !context.containsBean(MicrostreamHealthIndicator)
+        !context.containsBean(MicroStreamHealthIndicator)
 
         cleanup:
         context.close()

--- a/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicroStreamMetricsBinderDisabledSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicroStreamMetricsBinderDisabledSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 @MicronautTest
-@Property(name = "spec.name", value = "MicrostreamMetricsBinderSpec")
+@Property(name = "spec.name", value = "MicroStreamMetricsBinderSpec")
 class MicroStreamMetricsBinderDisabledSpec extends Specification implements TestPropertyProvider {
 
     @TempDir

--- a/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicroStreamMetricsBinderSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/metrics/MicroStreamMetricsBinderSpec.groovy
@@ -18,7 +18,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 @MicronautTest
-@Property(name = "spec.name", value = "MicrostreamMetricsBinderSpec")
+@Property(name = "spec.name", value = "MicroStreamMetricsBinderSpec")
 class MicroStreamMetricsBinderSpec extends Specification implements TestPropertyProvider {
 
     @TempDir
@@ -81,7 +81,7 @@ class MicroStreamMetricsBinderSpec extends Specification implements TestProperty
     }
 
     @Singleton
-    @Requires(property = "spec.name", value = "MicrostreamMetricsBinderSpec")
+    @Requires(property = "spec.name", value = "MicroStreamMetricsBinderSpec")
     static class SpecController {
 
         private StorageManager townManager

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -12,5 +12,5 @@ with https://docs.micronaut.io/latest/guide/#qualifiers[Name Bean Qualifiers]: `
 include::test-suite/src/test/resources/application-multiple.yml[]
 ----
 
-<1> Specify a different name qualifier for each Microstream instance
+<1> Specify a different name qualifier for each MicroStream instance
 <2> Specify the class of the entity graph's root.

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,1 +1,1 @@
-Integration with https://microstream.one[Microstream].
+Integration with https://microstream.one[MicroStream].

--- a/src/main/docs/guide/microstreamMetrics.adoc
+++ b/src/main/docs/guide/microstreamMetrics.adoc
@@ -1,3 +1,3 @@
-You can enable Microstream Metrics collection by enabling https://micronaut-projects.github.io/micronaut-micrometer/latest/guide[Micrometer Metrics].
+You can enable MicroStream Metrics collection by enabling https://micronaut-projects.github.io/micronaut-micrometer/latest/guide[Micrometer Metrics].
 
-If you do not wish to collect Microstream metrics, you can set `micronaut.metrics.binders.microstream.enabled` to `false` in `application.yml`.
+If you do not wish to collect MicroStream metrics, you can set `micronaut.metrics.binders.microstream.enabled` to `false` in `application.yml`.

--- a/src/main/docs/guide/rest/restConfiguration.adoc
+++ b/src/main/docs/guide/rest/restConfiguration.adoc
@@ -1,13 +1,3 @@
-Once you add the _microstream-rest_ dependency, it exposes the API by default. You can disable it with:
-
-[source,yaml]
-.src/main/resources/application.yml
-----
-microstream:
-  rest:
-    enabled: false
-----
-
 The API path is `/microstream` by default.
 
 NOTE: When multiple storage managers are defined, the URL must be suffixed by the manager name `/microstream/«storage-name»`.

--- a/src/main/docs/guide/rest/restSetup.adoc
+++ b/src/main/docs/guide/rest/restSetup.adoc
@@ -1,3 +1,15 @@
 To enable it, add the following dependency to your application.
 
 dependency:micronaut-microstream-rest[groupId="{projectGroup}",scope="developmentOnly"]
+
+You also need to enable it in your configuration, as for security it is disabled by default.
+
+[source,yaml]
+.src/main/resources/application.yml
+----
+microstream:
+  rest:
+    enabled: true
+----
+
+It will output a warning each time your application is started if the REST endpoint is enabled that this should not be deployed to production.

--- a/src/main/docs/guide/rootInstance.adoc
+++ b/src/main/docs/guide/rootInstance.adoc
@@ -14,5 +14,5 @@ You specify the Root class via configuration:
 include::test-suite/src/test/resources/application-data.yml[]
 ----
 
-<1> Specify a name qualifier for the Microstream instance
+<1> Specify a name qualifier for the MicroStream instance
 <2> Specify the class of the entity graph's root.

--- a/src/main/docs/guide/storage/storageWithStorageManager.adoc
+++ b/src/main/docs/guide/storage/storageWithStorageManager.adoc
@@ -2,8 +2,8 @@ The following example shows how to create a repository which injects the `Storag
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryImpl[tags=clazz]
 
-<1> If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject `StorageManager`.
-<2> When you are https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data[working with Microstream technology in a multi-threaded environment],
+<1> If your Micronaut application has only a single MicroStream Instance, you don't need to specify a name qualifier to inject `StorageManager`.
+<2> When you are https://docs.microstream.one/manual/storage/root-instances.html#_shared_mutable_data[working with MicroStream technology in a multi-threaded environment],
 reading and writing to this shared object graph must be synchronized.
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 

--- a/src/main/docs/guide/storage/storageWithStore.adoc
+++ b/src/main/docs/guide/storage/storageWithStore.adoc
@@ -2,7 +2,7 @@ The following example shows how an equivalent implementation which leverages the
 
 snippet::io.micronaut.microstream.docs.CustomerRepositoryStoreImpl[tags=clazz]
 
-<1> You can also inject an instance of api:microstream.RootProvider[] to easily access the Microstream Root Instance. If your Micronaut application has only a single Microstream Instance, you don't need to specify a name qualifier to inject it.
+<1> You can also inject an instance of api:microstream.RootProvider[] to easily access the MicroStream Root Instance. If your Micronaut application has only a single MicroStream Instance, you don't need to specify a name qualifier to inject it.
 <2> https://docs.microstream.one/manual/storage/storing-data/index.html[The rule is: "The Object that has been modified has to be stored!"].
 <3> https://docs.microstream.one/manual/storage/storing-data/index.html[To store a newly created object, store the "owner" of the object].
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/microstream/docs/CustomerControllerSpec.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 class CustomerControllerSpec extends Specification {
 
     @Unroll
-    void "verify CRUD with Microstream"(String customerRepositoryImplementation) {
+    void "verify CRUD with MicroStream"(String customerRepositoryImplementation) {
         given:
         String storageDirectory = "build/microstream-" + UUID.randomUUID()
         ServerAndClient server = startServer(serverProperties(storageDirectory, customerRepositoryImplementation))

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerControllerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/microstream/docs/CustomerControllerTest.kt
@@ -19,7 +19,7 @@ class CustomerControllerTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["embedded-storage-manager", "store"])
-    fun verifyCrudWithMicrostream(customerRepositoryImplementation: String) {
+    fun verifyCrudWithMicroStream(customerRepositoryImplementation: String) {
         // Given
         var server = startServer(customerRepositoryImplementation)
         val sergioName = "Sergio"

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/CustomerControllerTest.java
@@ -34,7 +34,7 @@ class CustomerControllerTest {
         "store-root-eager",
         "store-annotation"
     })
-    void verifyCrudWithMicrostream(String customerRepositoryImplementation) throws Exception {
+    void verifyCrudWithMicroStream(String customerRepositoryImplementation) throws Exception {
         // Given
         String storageDirectory = "build/microstream-" + UUID.randomUUID();
         Map<String, Object> properties = CollectionUtils.mapOf(


### PR DESCRIPTION
**We need to decide which way to go, but I thought I'd pre-empt rolling back with this PR**

After todays meeting, I am hesitant to enable the rest endpoint by default.

Usually, to gain access to data you need access to a database, knowledge of the type of
database, and credentials for it.

With this, there are no credentials, and it runs on a port that you already have open.

This change switches back to being disabled by default, and adds a warning log if it's enabled at application
startup.