### PR TITLE
Allow running the REST Cli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,4 +2,5 @@ plugins {
     id "io.micronaut.build.internal.docs"
     id "io.micronaut.build.internal.dependency-updates"
     id "io.micronaut.build.internal.quality-reporting"
+    id "io.micronaut.internal.build.microstream-rest-cli"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("groovy-gradle-plugin")
+}

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.microstream-rest-cli.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.microstream-rest-cli.gradle
@@ -1,0 +1,23 @@
+configurations {
+    create("cli")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    cli(libs.microstream.rest.gui) {
+        artifact {
+            type = "jar"
+            transitive = false
+        }
+    }
+}
+
+tasks.register("runCli", JavaExec) {
+    group = "cli"
+    description = "Runs the CLI"
+    classpath = files(configurations.named("cli").map { it.singleFile }.get())
+    it.args('--server.port=8888')
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ managed-microstream-storage-embedded-configuration = { module = 'one.microstream
 managed-microstream-cache = { module = 'one.microstream:microstream-cache', version.ref = 'managed-microstream' }
 managed-microstream-storage-restservice = { module = 'one.microstream:microstream-storage-restservice', version.ref = 'managed-microstream' }
 
+microstream-rest-gui = { module = 'one.microstream:microstream-storage-restclient-app', version.ref = 'managed-microstream' }
+
 logback-classic = { module = 'ch.qos.logback:logback-classic' }
 
 jupiter-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params' }


### PR DESCRIPTION
This is not user facing, it's purely for our benefit triaging issues we may have

./gradlew runCli

Will pull the correct client version and run it on port 8888