### PR TITLE
Add BinaryHandlersJDK8 by default

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ managed-microstream-cache = { module = 'one.microstream:microstream-cache', vers
 managed-microstream-storage-restservice = { module = 'one.microstream:microstream-storage-restservice', version.ref = 'managed-microstream' }
 
 microstream-rest-gui = { module = 'one.microstream:microstream-storage-restclient-app', version.ref = 'managed-microstream' }
+microstream-persistence-binary-jdk8 = { module = 'one.microstream:microstream-persistence-binary-jdk8', version.ref = 'managed-microstream' }
 
 logback-classic = { module = 'ch.qos.logback:logback-classic' }
 

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSingleStorageSpec.groovy
@@ -85,13 +85,15 @@ class MicroStreamRestControllerSingleStorageSpec extends Specification implement
 
         then:
         obj.objectId == id
-        obj.data.size() == 1
+
+        // With the Jdk8 persistence layer, the first item is a list capacity, and the second the list itself
+        obj.data.size() == 2
         // Which contains 2 items
-        obj.data[0].size() == 2
+        obj.data[1].size() == 2
 
         when:
-        String timId = obj.data[0][0]
-        String sergioId = obj.data[0][1]
+        String timId = obj.data[1][0]
+        String sergioId = obj.data[1][1]
 
         def tim = object(timId)
         def sergio = object(sergioId)

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
@@ -94,13 +94,15 @@ class MicroStreamRestControllerSpec extends Specification implements TestPropert
 
         then:
         obj.objectId == id
-        obj.data.size() == 1
+
+        // With the Jdk8 persistence layer, the first item is a list capacity, and the second the list itself
+        obj.data.size() == 2
         // Which contains 2 items
-        obj.data[0].size() == 2
+        obj.data[1].size() == 2
 
         when:
-        String timId = obj.data[0][0]
-        String sergioId = obj.data[0][1]
+        String timId = obj.data[1][0]
+        String sergioId = obj.data[1][1]
 
         def tim = object(timId)
         def sergio = object(sergioId)

--- a/microstream/build.gradle.kts
+++ b/microstream/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
     compileOnly(mn.micronaut.management)
     implementation(libs.projectreactor)
+    implementation(libs.microstream.persistence.binary.jdk8)
 
     testImplementation(libs.projectreactor.test)
     testImplementation(mn.micronaut.micrometer.core)

--- a/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactory.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.microstream.conf;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import jakarta.inject.Singleton;
+import one.microstream.persistence.binary.jdk8.types.BinaryHandlersJDK8;
 import one.microstream.storage.embedded.types.EmbeddedStorageFoundation;
 
 /**
@@ -36,6 +37,7 @@ public class EmbeddedStorageFoundationFactory {
     @EachBean(EmbeddedStorageConfigurationProvider.class)
     @Singleton
     EmbeddedStorageFoundation<?> createFoundation(EmbeddedStorageConfigurationProvider provider) {
-        return provider.getBuilder().createEmbeddedStorageFoundation();
+        return provider.getBuilder().createEmbeddedStorageFoundation()
+            .onConnectionFoundation(BinaryHandlersJDK8::registerJDK8TypeHandlers);
     }
 }


### PR DESCRIPTION
The JDK8 binary handlers are optimized to reduce memory overhead and increase performance.

As we require Java 8 as a minimum, we can add these by default to any Storage Foundation that is created