### PR TITLE
Fix Java code listings to match the docs

### DIFF
--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
@@ -1,12 +1,12 @@
 package io.micronaut.microstream.docs;
 
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.serde.annotation.Serdeable;
 
 import javax.validation.constraints.NotBlank;
 
-@Serdeable
+@Introspected
 public class Customer {
     @NonNull
     @NotBlank

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
@@ -1,12 +1,12 @@
 package io.micronaut.microstream.docs;
 
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Serdeable // <1>
+@Introspected // <1>
 public class Data {
     private Map<String, Customer> customers = new HashMap<>();
 


### PR DESCRIPTION
The Java guide shows a wrong code listing. 

<img width="1371" alt="Cursor_and_Micronaut_MicroStream" src="https://user-images.githubusercontent.com/71073/191913305-2af7d8cf-8fe6-4d0c-816a-08825c639b7c.png">

