### PR TITLE
Fix Java code listings to match the docs

### DIFF
--- a/src/main/docs/guide/rootInstance.adoc
+++ b/src/main/docs/guide/rootInstance.adoc
@@ -1,10 +1,12 @@
-The following example creates a https://docs.microstream.one/manual/storage/root-instances.html[Root Instance] to store `Customer`s:
+The following example creates a https://docs.microstream.one/manual/storage/root-instances.html[Root Instance] to store ``Customer``s:
 
 snippet::io.micronaut.microstream.docs.Data[]
 
-<1> Annotate the Root class with https://docs.micronaut.io/latest/api/io/micronaut/core/annotation/Introspected.html[@Introspected] to generate https://docs.micronaut.io/latest/guide/#introspection[BeanIntrospection] metadata at compilation time. This information is used by the Micronaut Framework to instantiate the class without using reflection.
+And `Customer` is defined as:
 
 snippet::io.micronaut.microstream.docs.Customer[]
+
+<1> The type is annotated with https://micronaut-projects.github.io/micronaut-serialization/snapshot/api/io/micronaut/serde/annotation/Serdeable.html[@Serdeable] to enable serialization/deserialization
 
 You specify the Root class via configuration:
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
@@ -1,12 +1,12 @@
 package io.micronaut.microstream.docs;
 
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
 
 import javax.validation.constraints.NotBlank;
 
-@Introspected
+@Serdeable // <1>
 public class Customer {
     @NonNull
     @NotBlank

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Customer.java
@@ -1,12 +1,12 @@
 package io.micronaut.microstream.docs;
 
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.serde.annotation.Serdeable;
 
 import javax.validation.constraints.NotBlank;
 
-@Serdeable
+@Introspected
 public class Customer {
     @NonNull
     @NotBlank

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
@@ -1,12 +1,10 @@
 package io.micronaut.microstream.docs;
 
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Introspected // <1>
 public class Data {
     private Map<String, Customer> customers = new HashMap<>();
 

--- a/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
+++ b/test-suite/src/test/java/io/micronaut/microstream/docs/Data.java
@@ -1,12 +1,12 @@
 package io.micronaut.microstream.docs;
 
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Serdeable // <1>
+@Introspected // <1>
 public class Data {
     private Map<String, Customer> customers = new HashMap<>();
 


### PR DESCRIPTION
Supersedes #119

We don't need to Introspect or serialize the RootObject, but we do need @Serdeable on the customer for serialization, and this should be documented

Also fixed bad backticks around pluralized `Customer` in the docs