### PR TITLE
Add JDK17 type handlers

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['17']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['17']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/build.gradle
+++ b/build.gradle
@@ -4,3 +4,8 @@ plugins {
     id "io.micronaut.build.internal.quality-reporting"
     id "io.micronaut.internal.build.microstream-rest-cli"
 }
+
+micronautBuild {
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.microstream-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.microstream-base.gradle
@@ -2,3 +2,4 @@ repositories {
     mavenCentral()
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ managed-microstream-storage-restservice = { module = 'one.microstream:microstrea
 
 microstream-rest-gui = { module = 'one.microstream:microstream-storage-restclient-app', version.ref = 'managed-microstream' }
 microstream-persistence-binary-jdk8 = { module = 'one.microstream:microstream-persistence-binary-jdk8', version.ref = 'managed-microstream' }
+microstream-persistence-binary-jdk17 = { module = 'one.microstream:microstream-persistence-binary-jdk17', version.ref = 'managed-microstream' }
 
 logback-classic = { module = 'ch.qos.logback:logback-classic' }
 

--- a/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
+++ b/microstream-rest/src/test/groovy/io/micronaut/microstream/rest/MicroStreamRestControllerSpec.groovy
@@ -64,6 +64,12 @@ class MicroStreamRestControllerSpec extends Specification implements TestPropert
 
         then:
         dictionary.contains('primitive 8 bit integer signed')
+
+        and: 'Contains JDK8 loadFactor addition'
+        dictionary.contains('java.util.LinkedHashSet{\n\tfloat  loadFactor')
+
+        and: 'Contains JDK17 addition'
+        dictionary.contains('java.util.ImmutableCollections$Set12')
     }
 
     void 'Object traversal works as expected'() {

--- a/microstream/build.gradle.kts
+++ b/microstream/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     compileOnly(mn.micronaut.management)
     implementation(libs.projectreactor)
     implementation(libs.microstream.persistence.binary.jdk8)
+    implementation(libs.microstream.persistence.binary.jdk17)
 
     testImplementation(libs.projectreactor.test)
     testImplementation(mn.micronaut.micrometer.core)

--- a/microstream/src/main/java/io/micronaut/microstream/conf/DefaultEmbeddedStorageConfigurationProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/DefaultEmbeddedStorageConfigurationProvider.java
@@ -29,11 +29,14 @@ import one.microstream.storage.embedded.configuration.types.EmbeddedStorageConfi
  */
 @EachProperty("microstream.storage")
 public class DefaultEmbeddedStorageConfigurationProvider implements EmbeddedStorageConfigurationProvider {
+
     @ConfigurationBuilder
     EmbeddedStorageConfigurationBuilder builder = EmbeddedStorageConfiguration.Builder();
 
     @Nullable
     private Class<?> rootClass;
+
+    private boolean enableJdk17Types = DEFAULT_ENABLE_JDK17_TYPES;
 
     private final String name;
 
@@ -66,5 +69,20 @@ public class DefaultEmbeddedStorageConfigurationProvider implements EmbeddedStor
      */
     public void setRootClass(@NonNull Class<?> rootClass) {
         this.rootClass = rootClass;
+    }
+
+    @Override
+    public boolean isEnableJdk17Types() {
+        return enableJdk17Types;
+    }
+
+    /**
+     * Configure whether JDK 17 type enhancements are enabled. Defaults to {@value EmbeddedStorageConfigurationProvider#DEFAULT_ENABLE_JDK17_TYPES}.
+     *
+     * @since 2.0.0
+     * @param enableJdk17Types whether JDK 17 type enhancements are enabled.
+     */
+    public void setEnableJdk17Types(boolean enableJdk17Types) {
+        this.enableJdk17Types = enableJdk17Types;
     }
 }

--- a/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageConfigurationProvider.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageConfigurationProvider.java
@@ -26,6 +26,8 @@ import one.microstream.storage.embedded.configuration.types.EmbeddedStorageConfi
  */
 public interface EmbeddedStorageConfigurationProvider extends Named {
 
+    boolean DEFAULT_ENABLE_JDK17_TYPES = true;
+
     @NonNull
     EmbeddedStorageConfigurationBuilder getBuilder();
 
@@ -36,4 +38,12 @@ public interface EmbeddedStorageConfigurationProvider extends Named {
      */
     @Nullable
     Class<?> getRootClass();
+
+    /**
+     * Configure whether JDK 17 type enhancements are enabled. Defaults to {@value EmbeddedStorageConfigurationProvider#DEFAULT_ENABLE_JDK17_TYPES}.
+     *
+     * @since 2.0.0
+     * @return whether JDK 17 type enhancements are enabled.
+     */
+    boolean isEnableJdk17Types();
 }

--- a/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactory.java
+++ b/microstream/src/main/java/io/micronaut/microstream/conf/EmbeddedStorageFoundationFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.microstream.conf;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import jakarta.inject.Singleton;
+import one.microstream.persistence.binary.jdk17.types.BinaryHandlersJDK17;
 import one.microstream.persistence.binary.jdk8.types.BinaryHandlersJDK8;
 import one.microstream.storage.embedded.types.EmbeddedStorageFoundation;
 
@@ -37,7 +38,11 @@ public class EmbeddedStorageFoundationFactory {
     @EachBean(EmbeddedStorageConfigurationProvider.class)
     @Singleton
     EmbeddedStorageFoundation<?> createFoundation(EmbeddedStorageConfigurationProvider provider) {
-        return provider.getBuilder().createEmbeddedStorageFoundation()
+        EmbeddedStorageFoundation<?> foundation = provider.getBuilder().createEmbeddedStorageFoundation()
             .onConnectionFoundation(BinaryHandlersJDK8::registerJDK8TypeHandlers);
+        if (provider.isEnableJdk17Types()) {
+            foundation.onConnectionFoundation(BinaryHandlersJDK17::registerJDK17TypeHandlers);
+        }
+        return foundation;
     }
 }

--- a/microstream/src/test/groovy/io/micronaut/microstream/conf/Jdk17TypeSpec.groovy
+++ b/microstream/src/test/groovy/io/micronaut/microstream/conf/Jdk17TypeSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.microstream.conf
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.runtime.server.EmbeddedServer
+import one.microstream.storage.types.StorageManager
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class Jdk17TypeSpec extends Specification {
+
+    @TempDir
+    @Shared
+    File tempDir
+
+    void "jdk17 types are enabled by default"() {
+        given:
+        EmbeddedServer ctx = ApplicationContext.run(EmbeddedServer, [
+                "microstream.storage.default.root-class": BlueFlowers.class.name,
+                "microstream.storage.default.storage-directory": new File(tempDir, "orange").absolutePath,
+                ], Environment.TEST)
+        def manager = ctx.applicationContext.getBean(StorageManager)
+
+        expect:
+        manager.typeDictionary().lookupTypeByName('java.util.ImmutableCollections$Set12') != null
+
+        cleanup:
+        ctx.stop()
+    }
+
+    void "jdk17 types can be disabled"() {
+        given:
+        EmbeddedServer ctx = ApplicationContext.run(EmbeddedServer, [
+                "microstream.storage.default.root-class": BlueFlowers.class.name,
+                "microstream.storage.default.enable-jdk17-types": 'false',
+                "microstream.storage.default.storage-directory": new File(tempDir, "orange").absolutePath,
+        ], Environment.TEST)
+        def manager = ctx.applicationContext.getBean(StorageManager)
+
+        when:
+        manager.typeDictionary().lookupTypeByName('java.util.ImmutableCollections$Set12') == null
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        ctx.stop()
+    }
+
+    @Introspected
+    static class BlueFlowers {
+        List<String> flowers = []
+    }
+}


### PR DESCRIPTION
Switched the build to JDK 17 only, but should be ok as master is now the next major release

Added a feature toggle to turn this off, as it adds new types to the dictionary, so is probably incompatible with an existing root object storage.

Closes #21 
Closes #50